### PR TITLE
Fuse: Correct JMX path in RouteEditing test

### DIFF
--- a/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/RouteManipulationTest.java
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/RouteManipulationTest.java
@@ -92,7 +92,7 @@ public class RouteManipulationTest {
 		CamelEditor.switchTab("Design");
 		editor.save();
 		new WaitUntil(new ConsoleHasText("file://src/data] route1                         INFO  YYY"));
-		assertNotNull(jmx.getNode("Local Camel Context", "Camel", "camel-1", "Routes", "route1", "file:src/data?noop=true", "choice1", "choice1", "log1", "to1"));
+		assertNotNull(jmx.getNode("Local Camel Context", "Camel", "camel-1", "Routes", "route1", "file:src/data?noop=true", "choice1", "when1", "log1", "to1"));
 		assertNull(jmx.getNode("Local Camel Context", "Camel", "camel-1", "Routes", "route1", "file:src/data?noop=true", "choice1", "otherwise"));
 	}
 


### PR DESCRIPTION
In _RouteManipulationTest.java_ on line 95 (_testRemoteRouteEditing_) is an error in JMX path - "choice1", "choice1"
