### PR TITLE
Teiid: Fix pom.xml - add reddeer.config

### DIFF
--- a/tests/org.jboss.tools.teiid.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.teiid.ui.bot.test/pom.xml
@@ -12,9 +12,10 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>
+		<reddeer.config>notSpecified</reddeer.config>
 		<swtbot.properties>swtbot.properties</swtbot.properties>
 		<swtbot.test.properties.file>${swtbot.properties}</swtbot.test.properties.file>
-		<systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.properties.file=${swtbot.test.properties.file}</systemProperties>
+		<systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.properties.file=${swtbot.test.properties.file} -Dreddeer.config=${reddeer.config}</systemProperties>
 		<test.package>org.jboss.tools.teiid.ui.bot.test.suite</test.package>
 		<test.class>SmokeTests</test.class>
 		<jdbc.dir>${requirementsDirectory}/lib</jdbc.dir>


### PR DESCRIPTION
Tests using _@TeiidServer_ cannot be run with Maven ---> _-Dreddeer.config=..._ is not propagated