### PR TITLE
Teiid: Fix SmokeTests

### DIFF
--- a/tests/org.jboss.tools.teiid.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.teiid.ui.bot.test/pom.xml
@@ -12,7 +12,9 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>
-		<reddeer.config>notSpecified</reddeer.config>
+		<server.name>AS-7.1.1.Final</server.name>
+		<server.home>${project.build.directory}/jboss-as-7.1.1.Final</server.home>
+		<reddeer.config>${project.build.directory}/config/as-711_teiid-830.xml</reddeer.config>
 		<swtbot.properties>swtbot.properties</swtbot.properties>
 		<swtbot.test.properties.file>${swtbot.properties}</swtbot.test.properties.file>
 		<systemProperties>${integrationTestsSystemProperties} -Dswtbot.test.properties.file=${swtbot.test.properties.file} -Dreddeer.config=${reddeer.config}</systemProperties>
@@ -254,6 +256,64 @@
 				</executions>
 			</plugin>
 
+			<!-- Download JBoss AS + Teiid -->	
+			<plugin>
+			  <groupId>com.googlecode.maven-download-plugin</groupId>
+			  <artifactId>download-maven-plugin</artifactId>
+			  <version>1.2.0</version>
+			  <executions>
+			    <execution>
+			      <id>get-as</id>
+			      <phase>pre-integration-test</phase>
+			      <goals>
+				<goal>wget</goal>
+			      </goals>
+			      <configuration>
+				<url>http://download.jboss.org/jbossas/7.1/jboss-as-7.1.1.Final/jboss-as-7.1.1.Final.zip</url>
+				<unpack>true</unpack>
+			      </configuration>
+			    </execution>
+			    <execution>
+			      <id>get-teiid</id>
+			      <phase>pre-integration-test</phase>
+			      <goals>
+				<goal>wget</goal>
+			      </goals>
+			      <configuration>
+				<url>https://sourceforge.net/projects/teiid/files/teiid-8.3.0.Final-jboss-dist.zip</url>
+				<unpack>true</unpack>
+				<outputDirectory>${project.build.directory}/jboss-as-7.1.1.Final</outputDirectory>
+			      </configuration>
+			    </execution>
+			  </executions>
+			</plugin>
+			<plugin>
+			  <artifactId>maven-resources-plugin</artifactId>
+			  <version>2.6</version>
+			  <executions>
+			    <execution>
+			      <id>copy-resources</id>
+			      <phase>validate</phase>
+			      <goals>
+				<goal>copy-resources</goal>
+			      </goals>
+			      <configuration>
+				<encoding>UTF-8</encoding>
+				<outputDirectory>${basedir}/target/</outputDirectory>
+				<resources>          
+				  <resource>
+				    <directory>resources</directory>
+				    <includes>
+				      <include>config/*</include>
+				    </includes>
+				    <filtering>true</filtering>
+				  </resource>
+				</resources>
+			      </configuration>            
+			    </execution>
+			  </executions>
+			</plugin>
+			
 			</plugins>
 	</build>
 

--- a/tests/org.jboss.tools.teiid.ui.bot.test/resources/config/as-711_teiid-830.xml
+++ b/tests/org.jboss.tools.teiid.ui.bot.test/resources/config/as-711_teiid-830.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testrun
+  xmlns="http://www.jboss.org/NS/Req"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:server="http://www.jboss.org/NS/SOAReq"
+  xmlns:runtime="http://www.jboss.org/NS/SOAReq"
+  xsi:schemaLocation="http://www.jboss.org/NS/Req	http://www.jboss.org/schema/reddeer/RedDeerSchema.xsd
+                      http://www.jboss.org/NS/SOAReq	http://www.jboss.org/schema/reddeer/3rdparty/SOARequirements.xsd">
+
+  <requirements>
+    <server:server-requirement name="${server.name}">
+      <server:as version="7.1">
+        <server:home>${server.home}</server:home>
+      </server:as>
+    </server:server-requirement>
+  </requirements>
+
+</testrun>


### PR DESCRIPTION
Teiid smoke test fails due to 

Error Message

The configuration location /home/jbossqa/workspace/jbtis.verification_matrix/31cc4d93/tests/org.jboss.tools.teiid.ui.bot.test/notSpecified does not exist

Stacktrace

org.jboss.reddeer.junit.configuration.RedDeerConfigurationException: The configuration location /home/jbossqa/workspace/jbtis.verification_matrix/31cc4d93/tests/org.jboss.tools.teiid.ui.bot.test/notSpecified does not exist
	at org.jboss.reddeer.junit.internal.configuration.SuiteConfiguration.getConfigurationFiles(SuiteConfiguration.java:76)
	at org.jboss.reddeer.junit.internal.configuration.SuiteConfiguration.getConfigurationFiles(SuiteConfiguration.java:71)
	at org.jboss.reddeer.junit.internal.configuration.SuiteConfiguration.findTestRunConfigurations(SuiteConfiguration.java:44)
	at org.jboss.reddeer.junit.internal.configuration.SuiteConfiguration.getTestRunConfigurations(SuiteConfiguration.java:35)
	at org.jboss.reddeer.junit.runner.RedDeerSuite.createSuite(RedDeerSuite.java:86)
	at org.jboss.reddeer.junit.runner.RedDeerSuite.<init>(RedDeerSuite.java:69)
	at org.jboss.reddeer.junit.runner.RedDeerSuite.<init>(RedDeerSuite.java:56)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:526)
	at org.junit.internal.builders.AnnotatedBuilder.buildRunner(AnnotatedBuilder.java:33)
	at org.junit.internal.builders.AnnotatedBuilder.runnerForClass(AnnotatedBuilder.java:21)
	at org.junit.runners.model.RunnerBuilder.safeRunnerForClass(RunnerBuilder.java:59)
	at org.junit.internal.builders.AllDefaultPossibilitiesBuilder.runnerForClass(AllDefaultPossibilitiesBuilder.java:26)
	at org.junit.runners.model.RunnerBuilder.safeRunnerForClass(RunnerBuilder.java:59)
	at org.junit.internal.requests.ClassRequest.getRunner(ClassRequest.java:26)
	at org.apache.maven.surefire.junit4.JUnit4TestSet.execute(JUnit4TestSet.java:51)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:123)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:104)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:164)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:110)
	at org.apache.maven.surefire.booter.SurefireStarter.invokeProvider(SurefireStarter.java:175)
	at org.apache.maven.surefire.booter.SurefireStarter.runSuitesInProcess(SurefireStarter.java:123)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:87)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:73)
	at java.lang.Thread.run(Thread.java:745)
