### PR TITLE
BPMN2: tests fail due to new bpmn2 feature in 4.2.0.CR1

### DIFF
--- a/tests/org.jboss.tools.bpmn2.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.bpmn2.ui.bot.test/pom.xml
@@ -117,8 +117,8 @@
 				</dependency>
 				<dependency>
 				  <type>p2-installable-unit</type>
-				  <artifactId>org.eclipse.bpmn2.feature.feature.group</artifactId>
-				  <version>0.7.0</version>
+				  <artifactId>org.eclipse.bpmn2.feature.group</artifactId>
+				  <version>1.0.0</version>
 				</dependency>
 				
 				<!-- jBPM wizard  -->


### PR DESCRIPTION
[ERROR] Failed to execute goal org.eclipse.tycho:tycho-surefire-plugin:0.21.0:test (default-test) on project org.jboss.tools.bpmn2.ui.bot.test: Execution default-test of goal org.eclipse.tycho:tycho-surefire-plugin:0.21.0:test failed: No solution found because the problem is unsatisfiable.: [Unable to satisfy dependency from tycho-extra-1421667569646 0.0.0.1421667569646 to org.eclipse.bpmn2.feature.feature.group 0.7.0.; Unable to satisfy dependency from tycho-1421667569676 0.0.0.1421667569676 to org.eclipse.bpmn2.feature.feature.group 0.7.0.; No solution found because the problem is unsatisfiable.] -> [Help 1]