### PR TITLE
BPMN2: Tests fail on Windows

### DIFF
--- a/tests/org.jboss.tools.bpmn2.ui.bot.test/src/org/jboss/tools/bpmn2/ui/bot/test/JBPM6BaseTest.java
+++ b/tests/org.jboss.tools.bpmn2.ui.bot.test/src/org/jboss/tools/bpmn2/ui/bot/test/JBPM6BaseTest.java
@@ -21,6 +21,7 @@ import org.jboss.reddeer.swt.util.Display;
 import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitUntil;
 import org.jboss.reddeer.swt.wait.WaitWhile;
+import org.jboss.reddeer.workbench.impl.editor.DefaultEditor;
 import org.jboss.tools.bpmn2.reddeer.ProcessEditorView;
 import org.jboss.tools.bpmn2.ui.bot.test.requirements.ProcessDefinitionRequirement.ProcessDefinition;
 import org.jboss.tools.bpmn2.ui.bot.test.validator.JBPM6Validator;
@@ -214,7 +215,8 @@ public abstract class JBPM6BaseTest extends SWTBotTestCase {
 		new SWTWorkbenchBot().closeAllShells();
 		log.info("Closing '" + editor.getTitle() + "'");
 		saveProcessModel();
-		editor.close();
+		// editor.close();
+		new DefaultEditor(definition.name()).close();
 	}
 	
 	/**


### PR DESCRIPTION
Always the second test fails on Windows. The palette tools and the process itself is not rendered correctly.

Note that we were not able to reproduce this manually.