### PR TITLE
Fuse: Allow to run tests without specifying JBoss Fuse Server

### DIFF
--- a/tests/org.jboss.tools.fuse.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/pom.xml
@@ -12,13 +12,21 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>
-		<reddeer.config>resources/serverConfig/fuse-6.1.xml</reddeer.config>
+		<fuse.url>http://download.eng.bos.redhat.com/brewroot/repos/jb-fuse-6-rhel-6-build/latest/maven/org/jboss/fuse/jboss-fuse-full/6.1.0.redhat-379/jboss-fuse-full-6.1.0.redhat-379.zip</fuse.url>
+		<fuse.name>JBoss Fuse 6.1</fuse.name>
+		<fuse.path>${project.build.directory}/requirements/jboss-fuse-6.1.0.redhat-379</fuse.path>
+		<fuse.hostname>localhost</fuse.hostname>
+		<fuse.port>8101</fuse.port>
+		<fuse.username>admin</fuse.username>
+		<fuse.password>admin</fuse.password>
+		<reddeer.config>${project.build.directory}/requirements/</reddeer.config>
 		<systemProperties>${integrationTestsSystemProperties} -Dreddeer.config=${reddeer.config}</systemProperties>
 		<surefire.timeout>10800</surefire.timeout>
 		<test.class>AllTests</test.class>
 	</properties>
 
 	<build>
+
 		<plugins>
 			<!-- Fuse Bot Tests -->
 			<plugin>
@@ -71,6 +79,71 @@
 					</dependencies>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>2.6</version>
+				<executions>
+					<execution>
+						<id>copy-resources</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<encoding>UTF-8</encoding>
+							<outputDirectory>${project.build.directory}/requirements</outputDirectory>
+							<resources>
+								<resource>
+									<directory>resources/serverConfig</directory>
+									<filtering>true</filtering>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>com.googlecode.maven-download-plugin</groupId>
+				<artifactId>maven-download-plugin</artifactId>
+				<version>1.0.0</version>
+				<executions>
+					<execution>
+						<id>get-fuse</id>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>wget</goal>
+						</goals>
+						<configuration>
+							<url>${fuse.url}</url>
+							<unpack>true</unpack>
+							<outputDirectory>${project.build.directory}/requirements</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>1.7</version>
+				<executions>
+					<execution>
+						<id>set-users</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target>
+								<echo
+									file="${project.build.directory}/requirements/jboss-fuse-6.1.0.redhat-379/etc/users.properties">${fuse.username}=${fuse.password},admin</echo>
+							</target>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 		</plugins>
 	</build>
 </project>

--- a/tests/org.jboss.tools.fuse.ui.bot.test/resources/serverConfig/fuse-6.1.xml
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/resources/serverConfig/fuse-6.1.xml
@@ -1,25 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testrun
-  xmlns="http://www.jboss.org/NS/Req"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.jboss.org/NS/Req https://raw.github.com/jboss-reddeer/reddeer/master/plugins/org.jboss.reddeer.junit/resources/RedDeerRequirements.xsd">
+<testrun xmlns="http://www.jboss.org/NS/Req" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:server="http://www.jboss.org/NS/SOAReq"
+	xsi:schemaLocation="http://www.jboss.org/NS/Req       http://www.jboss.org/schema/reddeer/RedDeerSchema.xsd
+						http://www.jboss.org/NS/SOAReq    http://www.jboss.org/schema/reddeer/3rdparty/SOARequirements.xsd">
 
 	<requirements>
-		<requirement class="org.jboss.tools.fuse.ui.bot.test.requirement.ServerRequirement" name="serverRequirement">
-
-			<property key="runtime" value="JBoss Fuse 6.1"/>
-			<property key="path" value="target/requirements/jboss-fuse-6.1.0.redhat-312"/>
-
-			<property key="type" value="JBoss Fuse 6.1 Server"/>
-			<property key="hostname" value="localhost"/>
-			<property key="name" value="JBoss Fuse 6.1 (localhost)"/>
-
-			<property key="port" value="8101"/>
-			<property key="username" value="admin"/>
-			<property key="password" value="admin"/>
-
-			<property key="jmxname" value="JBoss Fuse"/>
-	
-		</requirement>
+		<server:server-requirement name="${fuse.name}">
+			<server:fuse version="6.1">
+				<server:home>${fuse.path}</server:home>
+				<server:host>${fuse.hostname}</server:host>
+				<server:port>${fuse.port}</server:port>
+				<server:username>${fuse.username}</server:username>
+				<server:password>${fuse.password}</server:password>
+			</server:fuse>
+		</server:server-requirement>
 	</requirements>
+
 </testrun>


### PR DESCRIPTION
Allow to run Fuse tests with following command:
`mvn clean verify -pl tests/org.jboss.tools.fuse.ui.bot.test -am -fn`

*Note:* no _-Dreddeer.config_ is specified