### PR TITLE
Fuse: Fix malfunctioned user addition to Fuse server

### DIFF
--- a/tests/org.jboss.tools.fuse.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/pom.xml
@@ -130,7 +130,7 @@
 				<executions>
 					<execution>
 						<id>set-users</id>
-						<phase>verify</phase>
+						<phase>pre-integration-test</phase>
 						<goals>
 							<goal>run</goal>
 						</goals>


### PR DESCRIPTION
Maven plugin with id _set-users_ is not executed before tests run