### PR TITLE
SwitchYard: Smoke tests fail on RHEL 7

### DIFF
--- a/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/project/SwitchYardProject.java
+++ b/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/project/SwitchYardProject.java
@@ -14,6 +14,7 @@ import org.jboss.reddeer.swt.impl.button.CheckBox;
 import org.jboss.reddeer.swt.impl.button.PushButton;
 import org.jboss.reddeer.swt.impl.menu.ContextMenu;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
+import org.jboss.reddeer.swt.impl.shell.WorkbenchShell;
 import org.jboss.reddeer.swt.wait.AbstractWait;
 import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitWhile;
@@ -29,6 +30,7 @@ public class SwitchYardProject extends Project {
 	}
 
 	protected static TreeItem findTreeItem(String projectName) {
+		new WorkbenchShell().setFocus();
 		ProjectExplorer projectExplorer = new ProjectExplorer();
 		projectExplorer.open();
 		return projectExplorer.getProject(projectName).getTreeItem();

--- a/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/ProjectCreationTest.java
+++ b/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/ProjectCreationTest.java
@@ -67,6 +67,8 @@ public class ProjectCreationTest {
 	@After
 	public void deleteSwitchYardProject() {
 		saveAndCloseSwitchYardFile();
+		new WorkbenchShell().setFocus();
+		new ProjectExplorer().open();
 		new ProjectExplorer().deleteAllProjects();
 	}
 


### PR DESCRIPTION
Error Message

No control has focus. Perhaps something has stolen it? Try to regain focus with for example "new DefaultShell()".

Stacktrace

org.jboss.reddeer.swt.exception.SWTLayerException: No control has focus. Perhaps something has stolen it? Try to regain focus with for example "new DefaultShell()".
	at org.jboss.reddeer.swt.lookup.MenuLookup.getTopMenuMenuItemsFromFocus(MenuLookup.java:175)
	at org.jboss.reddeer.swt.impl.menu.ContextMenu.<init>(ContextMenu.java:42)
	at org.jboss.reddeer.swt.impl.menu.ContextMenu.<init>(ContextMenu.java:33)
	at org.jboss.tools.switchyard.reddeer.project.SwitchYardProject.update(SwitchYardProject.java:55)
	at org.jboss.tools.switchyard.ui.bot.test.ProjectCreationTest.createProjectWithComponentsTest(ProjectCreationTest.java:192)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner$InvokeMethodWithException.evaluate(RequirementsRunner.java:275)
	at org.jboss.reddeer.junit.internal.runner.RunBefores.evaluate(RunBefores.java:48)
	at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:43)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.jboss.reddeer.junit.internal.runner.RunBefores.evaluate(RunBefores.java:48)
	at org.jboss.reddeer.junit.internal.runner.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:26)
	at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:43)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:112)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.apache.maven.surefire.junit4.JUnit4TestSet.execute(JUnit4TestSet.java:53)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:123)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:104)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:164)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:110)
	at org.apache.maven.surefire.booter.SurefireStarter.invokeProvider(SurefireStarter.java:175)
	at org.apache.maven.surefire.booter.SurefireStarter.runSuitesInProcess(SurefireStarter.java:123)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:87)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:73)
	at java.lang.Thread.run(Thread.java:745)

