### PR TITLE
Improve running smoke tests

### DIFF
--- a/tests/org.jboss.tools.bpel.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.bpel.ui.bot.test/pom.xml
@@ -12,8 +12,9 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>
-	  <reddeer.config>${project.build.directory}/classes/config</reddeer.config>
-	  <systemProperties>${integrationTestsSystemProperties} -Dreddeer.config=${reddeer.config}</systemProperties>
+	  <reddeer.config>${project.build.directory}/config</reddeer.config>
+	  <reddeerProperties>-Dreddeer.config=${reddeer.config}</reddeerProperties>
+	  <systemProperties>${integrationTestsSystemProperties} ${reddeerProperties}</systemProperties>
 	</properties>
 
 	<build>
@@ -65,6 +66,9 @@
 	      <groupId>com.googlecode.maven-download-plugin</groupId>
 	      <artifactId>download-maven-plugin</artifactId>
 	      <version>1.2.0</version>
+	      <configuration>
+		<skip>${skipRequirements}</skip>
+	      </configuration>
 	      <executions>
 		<execution>
 		  <id>install-as-5.1.0</id>
@@ -110,6 +114,9 @@
 	    <plugin>
 	      <artifactId>maven-antrun-plugin</artifactId>
 	      <version>1.7</version>
+	      <configuration>
+		<skip>${skipRequirements}</skip>
+	      </configuration>
 	      <executions>
 		<execution>
 		  <id>install-esb</id>
@@ -148,18 +155,52 @@
 		</execution>
 	      </executions>
 	    </plugin>
+	    <!-- Copy resources and replace variables with its values -->
+	    <plugin>
+	      <artifactId>maven-resources-plugin</artifactId>
+	      <version>2.6</version>
+	      <executions>
+	        <execution>
+                  <id>copy-resources</id>
+	          <phase>validate</phase>
+	          <goals>
+	            <goal>copy-resources</goal>
+	          </goals>
+	          <configuration>
+	            <encoding>UTF-8</encoding>
+	            <outputDirectory>${project.build.directory}</outputDirectory>
+	            <resources>          
+	              <resource>
+	                <directory>resources</directory>
+			<includes>
+			  <include>config/*</include>
+			</includes>
+	                <filtering>true</filtering>
+	              </resource>
+	            </resources>
+	          </configuration>            
+	        </execution>
+	      </executions>
+	    </plugin>
 	  </plugins>
-	  <!-- Copy resources and replace variables with its values -->
-	  <resources>
-	    <resource>
-	      <directory>resources</directory>
-	      <includes>
-		<include>config/*</include>
-	      </includes>
-	      <filtering>true</filtering>
-	    </resource>
-	  </resources>
 	</build>
+	
+	<profiles>
+	  <profile>
+	    <id>smoke</id>
+	    <activation>
+	      <property>
+		<name>test</name>
+		<value>SmokeTests</value>
+	      </property>
+	    </activation>
+	    <properties>	      
+	      <reddeerProperties></reddeerProperties>
+	      <test.class>SmokeTests</test.class>
+	      <skipRequirements>true</skipRequirements>
+	    </properties>
+	  </profile>
+	</profiles>
 	
 </project>
       

--- a/tests/org.jboss.tools.esb.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.esb.ui.bot.test/pom.xml
@@ -12,8 +12,9 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>
-	  <reddeer.config>${project.build.directory}/classes/config</reddeer.config>
-	  <systemProperties>${integrationTestsSystemProperties} -Dreddeer.config=${reddeer.config}</systemProperties>
+	  <reddeer.config>${project.build.directory}/config</reddeer.config>
+	  <reddeerProperties>-Dreddeer.config=${reddeer.config}</reddeerProperties>
+	  <systemProperties>${integrationTestsSystemProperties} ${reddeerProperties}</systemProperties>
 	  <customization.file>resources/config/plugin_customization.ini</customization.file>
 	</properties>
 	
@@ -65,6 +66,9 @@
 	      <groupId>com.googlecode.maven-download-plugin</groupId>
 	      <artifactId>download-maven-plugin</artifactId>
 	      <version>1.2.0</version>
+	      <configuration>
+		<skip>${skipRequirements}</skip>
+	      </configuration>
 	      <executions>
 		<execution>
 		  <id>install-as-5.1.0</id>
@@ -97,6 +101,9 @@
 	    <plugin>
 	      <artifactId>maven-antrun-plugin</artifactId>
 	      <version>1.7</version>
+	      <configuration>
+		<skip>${skipRequirements}</skip>
+	      </configuration>
 	      <executions>
 		<execution>
 		  <id>install-esb</id>
@@ -105,7 +112,6 @@
 		    <goal>run</goal>
 		  </goals>
 		  <configuration>
-		    <skip>${skipTests}</skip>
 		    <target>
 		      <ant dir="${project.build.directory}/jbossesb-4.12/install" target="deploy">
 			<property name="org.jboss.esb.server.home" value="${project.build.directory}/jboss-5.1.0.GA" />
@@ -116,17 +122,51 @@
 		</execution>
 	      </executions>
 	    </plugin>
+	    <!-- Copy resources and replace variables with its values -->
+	    <plugin>
+	      <artifactId>maven-resources-plugin</artifactId>
+	      <version>2.6</version>
+	      <executions>
+	        <execution>
+                  <id>copy-resources</id>
+	          <phase>validate</phase>
+	          <goals>
+	            <goal>copy-resources</goal>
+	          </goals>
+	          <configuration>
+	            <encoding>UTF-8</encoding>
+	            <outputDirectory>${project.build.directory}</outputDirectory>
+	            <resources>          
+	              <resource>
+	                <directory>resources</directory>
+			<includes>
+			  <include>config/*</include>
+			</includes>
+	                <filtering>true</filtering>
+	              </resource>
+	            </resources>
+	          </configuration>            
+	        </execution>
+	      </executions>
+	    </plugin>
 	  </plugins>
-	  <!-- Copy resources and replace variables with its values -->
-	  <resources>
-	    <resource>
-	      <directory>resources</directory>
-	      <includes>
-		<include>config/*</include>
-	      </includes>
-	      <filtering>true</filtering>
-	    </resource>
-	  </resources>
 	</build>
 
+	<profiles>
+	  <profile>
+	    <id>smoke</id>
+	    <activation>
+	      <property>
+		<name>test</name>
+		<value>SmokeTests</value>
+	      </property>
+	    </activation>
+	    <properties>	      
+	      <reddeerProperties></reddeerProperties>
+	      <test.class>SmokeTests</test.class>
+	      <skipRequirements>true</skipRequirements>
+	    </properties>
+	  </profile>
+	</profiles>
+	
 </project>

--- a/tests/org.jboss.tools.fuse.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/pom.xml
@@ -108,6 +108,9 @@
 				<groupId>com.googlecode.maven-download-plugin</groupId>
 				<artifactId>maven-download-plugin</artifactId>
 				<version>1.0.0</version>
+				<configuration>
+				  <skip>${skipRequirements}</skip>
+				</configuration>
 				<executions>
 					<execution>
 						<id>get-fuse</id>
@@ -127,6 +130,9 @@
 			<plugin>
 				<artifactId>maven-antrun-plugin</artifactId>
 				<version>1.7</version>
+				<configuration>
+				  <skip>${skipRequirements}</skip>
+				</configuration>
 				<executions>
 					<execution>
 						<id>set-users</id>
@@ -146,4 +152,22 @@
 
 		</plugins>
 	</build>
+	
+	<profiles>
+	  <profile>
+	    <id>smoke</id>
+	    <activation>
+	      <property>
+		<name>test</name>
+		<value>SmokeTests</value>
+	      </property>
+	    </activation>
+	    <properties>	      
+	      <reddeerProperties></reddeerProperties>
+	      <test.class>SmokeTests</test.class>
+	      <skipRequirements>true</skipRequirements>
+	    </properties>
+	  </profile>
+	</profiles>
+	
 </project>

--- a/tests/org.jboss.tools.jbpm.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.jbpm.ui.bot.test/pom.xml
@@ -12,8 +12,9 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>
-	  <reddeer.config>${project.build.directory}/classes/config</reddeer.config>
-	  <systemProperties>${integrationTestsSystemProperties} -Dreddeer.config=${reddeer.config}</systemProperties>
+	  <reddeer.config>${project.build.directory}/config</reddeer.config>
+	  <reddeerProperties>-Dreddeer.config=${reddeer.config}</reddeerProperties>
+	  <systemProperties>${integrationTestsSystemProperties} ${reddeerProperties}</systemProperties>
 	  <maven-download-plugin.version>1.0.0</maven-download-plugin.version>
 	</properties>
 
@@ -57,6 +58,9 @@
 	      <groupId>com.googlecode.maven-download-plugin</groupId>
 	      <artifactId>download-maven-plugin</artifactId>
 	      <version>1.2.0</version>
+	      <configuration>
+		<skip>${skipRequirements}</skip>
+	      </configuration>
 	      <executions>
 		<execution>
 		  <id>download-as5</id>
@@ -89,6 +93,9 @@
 	    <plugin>
 	      <artifactId>maven-antrun-plugin</artifactId>
 	      <version>1.7</version>
+	      <configuration>
+		<skip>${skipRequirements}</skip>
+	      </configuration>
 	      <executions>
 		<execution>
 		  <id>install-jbpm</id>
@@ -101,25 +108,42 @@
 		      <java
 			  jar="${project.build.directory}/jbpm-distribution-3.2.9-installer.jar"
 			  dir="${project.build.directory}" fork="true">
-			<arg value="${project.build.directory}/classes/auto/install-jbpm3.xml" />
+			<arg value="${project.build.directory}/auto/install-jbpm3.xml" />
 		      </java>
 		    </tasks>
 		  </configuration>
 		</execution>
 	      </executions>
 	    </plugin>
+	    <!-- Copy resources and replace variables with its values -->
+	    <plugin>
+	      <artifactId>maven-resources-plugin</artifactId>
+	      <version>2.6</version>
+	      <executions>
+	        <execution>
+                  <id>copy-resources</id>
+	          <phase>validate</phase>
+	          <goals>
+	            <goal>copy-resources</goal>
+	          </goals>
+	          <configuration>
+	            <encoding>UTF-8</encoding>
+	            <outputDirectory>${project.build.directory}</outputDirectory>
+	            <resources>          
+	              <resource>
+	                <directory>resources</directory>
+			<includes>
+			  <include>auto/*</include>
+			  <include>config/*</include>
+			</includes>
+	                <filtering>true</filtering>
+	              </resource>
+	            </resources>
+	          </configuration>            
+	        </execution>
+	      </executions>
+	    </plugin>
 	  </plugins>
-	  <!-- Copy resources and replace variables with its values -->
-	  <resources>
-	    <resource>
-	      <directory>resources</directory>
-	      <includes>
-		<include>config/*</include>
-		<include>auto/*</include>
-	      </includes>
-	      <filtering>true</filtering>
-	    </resource>
-	  </resources>
 	</build>
 
 </project>

--- a/tests/org.jboss.tools.modeshape.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.modeshape.ui.bot.test/pom.xml
@@ -18,7 +18,8 @@
 		<modeshapeUser>admin</modeshapeUser>
 		<modeshapePassword>admin</modeshapePassword>
 		<reddeer.config>${project.build.directory}/config/as-711_modeshape-301.xml</reddeer.config>
-		<systemProperties>${integrationTestsSystemProperties} -Dreddeer.config=${reddeer.config}</systemProperties>
+		<reddeerProperties>-Dreddeer.config=${reddeer.config}</reddeerProperties>
+		<systemProperties>${integrationTestsSystemProperties} ${reddeerProperties}</systemProperties>
 		<surefire.timeout>10800</surefire.timeout>
 		<test.class>AllTests</test.class>
 	</properties>
@@ -86,6 +87,9 @@
 			<plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
 				<artifactId>maven-download-plugin</artifactId>
+				<configuration>
+				  <skip>${skipRequirements}</skip>
+				</configuration>
 				<executions>
 					<execution>
 						<id>install-as</id>
@@ -117,6 +121,9 @@
 			<plugin>
 				<artifactId>maven-antrun-plugin</artifactId>
 				<version>${maven.antrun.plugin.version}</version>
+				<configuration>
+				  <skip>${skipRequirements}</skip>
+				</configuration>
 				<executions>
 					<execution>
 						<id>prepare-modeshape</id>
@@ -162,5 +169,22 @@
 			</plugin>
 		</plugins>
 	</build>
+	      
+	<profiles>
+	  <profile>
+	    <id>smoke</id>
+	    <activation>
+	      <property>
+		<name>test</name>
+		<value>SmokeTests</value>
+	      </property>
+	    </activation>
+	    <properties>	      
+	      <reddeerProperties></reddeerProperties>
+	      <test.class>SmokeTests</test.class>
+	      <skipRequirements>true</skipRequirements>
+	    </properties>
+	  </profile>
+	</profiles>
 </project>
       

--- a/tests/org.jboss.tools.runtime.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.runtime.ui.bot.test/pom.xml
@@ -14,9 +14,10 @@
 	<properties>
 	  <server.jre>default</server.jre>
 	  <reddeer.config>${project.build.directory}/config</reddeer.config>
-	  <systemProperties>${integrationTestsSystemProperties} -Dreddeer.config=${reddeer.config}</systemProperties>
+	  <reddeerProperties>-Dreddeer.config=${reddeer.config}</reddeerProperties>
+	  <systemProperties>${integrationTestsSystemProperties} ${reddeerProperties}</systemProperties>
 	  <surefire.timeout>10800</surefire.timeout>
-	  <maven-download-plugin.version>1.0.0</maven-download-plugin.version>
+	  <maven-download-plugin.version>1.2.0</maven-download-plugin.version>
 	</properties>
 
 	<build>
@@ -94,6 +95,9 @@
 	      <groupId>com.googlecode.maven-download-plugin</groupId>
 	      <artifactId>download-maven-plugin</artifactId>
 	      <version>1.2.0</version>
+	      <configuration>
+		<skip>${skipRequirements}</skip>
+	      </configuration>
 	      <executions>
 		<execution>
 		  <id>download-jboss-esb</id>
@@ -165,6 +169,9 @@
 	    <plugin>
 	      <artifactId>maven-antrun-plugin</artifactId>
 	      <version>1.7</version>
+	      <configuration>
+		<skip>${skipRequirements}</skip>
+	      </configuration>
 	      <executions>
 		<execution>
 		  <id>install-jbpm3</id>
@@ -186,6 +193,23 @@
 	    </plugin>
 	  </plugins>
 	</build>
+	
+	<profiles>
+	  <profile>
+	    <id>smoke</id>
+	    <activation>
+	      <property>
+		<name>test</name>
+		<value>SmokeTests</value>
+	      </property>
+	    </activation>
+	    <properties>	      
+	      <reddeerProperties></reddeerProperties>
+	      <test.class>SmokeTests</test.class>
+	      <skipRequirements>true</skipRequirements>
+	    </properties>
+	  </profile>
+	</profiles>
 	
 </project>
       

--- a/tests/org.jboss.tools.switchyard.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.switchyard.ui.bot.test/pom.xml
@@ -76,6 +76,9 @@
 	      <groupId>com.googlecode.maven-download-plugin</groupId>
 	      <artifactId>download-maven-plugin</artifactId>
 	      <version>1.2.0</version>
+	      <configuration>
+		<skip>${skipRequirements}</skip>
+	      </configuration>
 	      <executions>
 		<execution>
 		  <id>get-wildfly</id>
@@ -134,6 +137,23 @@
 	    </plugin>
 	  </plugins>
 	</build>
+
+	<profiles>
+	  <profile>
+	    <id>smoke</id>
+	    <activation>
+	      <property>
+		<name>test</name>
+		<value>SmokeTests</value>
+	      </property>
+	    </activation>
+	    <properties>	      
+	      <reddeer.config>${project.build.directory}/config/switchyard-200.xml</reddeer.config>
+	      <test.class>SmokeTests</test.class>
+	      <skipRequirements>true</skipRequirements>
+	    </properties>
+	  </profile>
+	</profiles>
 	
       </project>
       

--- a/tests/org.jboss.tools.switchyard.ui.bot.test/resources/config/switchyard-200.xml
+++ b/tests/org.jboss.tools.switchyard.ui.bot.test/resources/config/switchyard-200.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testrun
+  xmlns="http://www.jboss.org/NS/Req"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:server="http://www.jboss.org/NS/SOAReq"
+  xmlns:switchyard="http://www.jboss.org/NS/SOAReq"
+  xsi:schemaLocation="http://www.jboss.org/NS/Req	http://www.jboss.org/schema/reddeer/RedDeerSchema.xsd
+                      http://www.jboss.org/NS/SOAReq	http://www.jboss.org/schema/reddeer/3rdparty/SOARequirements.xsd">
+
+  <requirements>
+    <switchyard:switchyard-requirement name="SwitchYard-2.0.0.Beta1">
+      <switchyard:configurationVersion>2.0</switchyard:configurationVersion>
+      <switchyard:libraryVersion>2.0.0.Beta1</switchyard:libraryVersion>
+    </switchyard:switchyard-requirement>
+  </requirements>
+
+</testrun>

--- a/tests/org.jboss.tools.teiid.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.teiid.ui.bot.test/pom.xml
@@ -44,6 +44,9 @@
 			<plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
 				<artifactId>download-maven-plugin</artifactId>
+				<configuration>
+				  <skip>${skipRequirements}</skip>
+				</configuration>
 				<version>1.2.0</version>
 				<executions>
 					<execution>
@@ -315,5 +318,23 @@
 		</plugins>
 	</build>
 
+	<profiles>
+	  <profile>
+	    <id>smoke</id>
+	    <activation>
+	      <property>
+		<name>test</name>
+		<value>SmokeTests</value>
+	      </property>
+	    </activation>
+	    <properties>	      
+	      <reddeerProperties></reddeerProperties>
+	      <test.class>SmokeTests</test.class>
+	      <skipRequirements>true</skipRequirements>
+	      <get.drivers>true</get.drivers>
+	    </properties>
+	  </profile>
+	</profiles>
+	
 </project>
 


### PR DESCRIPTION
Current problems
* there is one new instance for each module (project)
* downloading/copying server files which are not used

I suggest the following
* create new project which will contain smoke tests from all projects
* add an option to disable preparing servers (ideally when you use -Dtest=SmokeTests)