### PR TITLE
Drools: Brms 5 binaries cannot be downloaded

### DIFF
--- a/tests/org.jboss.tools.drools.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.drools.ui.bot.test/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <plugin.version>6.0.1.Final</plugin.version>
-    <binaries.brms5>http://jawa05.englab.brq.redhat.com/released/BRMS-5.3.1.GA-deployable/brms-p-5.3.1.GA-deployable.zip</binaries.brms5>
+    <binaries.brms5>http://download.devel.redhat.com/released/JBossBRMS/5.3.1/brms-p-5.3.1.GA-deployable.zip</binaries.brms5>
   </properties>
 
   <build>


### PR DESCRIPTION
Brms 5 binaries was downloaded from http://jawa05.englab.brq.redhat.com. The address is down and it looks like it will not be available in the future.