### PR TITLE
SwitchYard: ignore some errors in quickstart tests

### DIFF
--- a/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/condition/ErrorsExist.java
+++ b/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/condition/ErrorsExist.java
@@ -1,0 +1,36 @@
+package org.jboss.tools.switchyard.reddeer.condition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.reddeer.eclipse.ui.problems.ProblemsView;
+import org.jboss.reddeer.swt.api.TreeItem;
+import org.jboss.reddeer.swt.condition.WaitCondition;
+
+/**
+ * 
+ * @author apodhrad
+ *
+ */
+public class ErrorsExist implements WaitCondition {
+	
+	private List<TreeItem> errors = new ArrayList<TreeItem>();
+
+	@Override
+	public boolean test() {
+		ProblemsView problemsView = new ProblemsView();
+		problemsView.open();
+		errors = problemsView.getAllErrors();
+		return !errors.isEmpty();
+	}
+
+	@Override
+	public String description() {
+		return "There are no errors in Problems view";
+	}
+	
+	public List<TreeItem> getAllErrors() {
+		return errors;
+	}
+
+}

--- a/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/wizard/ImportMavenWizard.java
+++ b/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/wizard/ImportMavenWizard.java
@@ -1,7 +1,7 @@
 package org.jboss.tools.switchyard.reddeer.wizard;
 
 import org.jboss.reddeer.eclipse.jdt.ui.ProjectExplorer;
-import org.jboss.reddeer.eclipse.jface.wizard.ImportWizardDialog;
+import org.jboss.reddeer.jface.wizard.ImportWizardDialog;
 import org.jboss.reddeer.swt.condition.JobIsRunning;
 import org.jboss.reddeer.swt.condition.ShellWithTextIsActive;
 import org.jboss.reddeer.swt.condition.WaitCondition;
@@ -33,6 +33,14 @@ public class ImportMavenWizard extends ImportWizardDialog {
 			new PushButton("Next >").click();
 		}
 		new PushButton("Finish").click();
+		new WaitWhile(new ShellWithTextIsActive("Import Maven Projects"), TimePeriod.NORMAL, false);
+		try {
+			new DefaultShell("Import Maven Projects");
+			new PushButton("Resolve All Later").click();
+			new PushButton("Finish").click();
+		} catch (Exception e) {
+			// ok, it means that the warning wasn't displayed
+		}
 		try {
 			new DefaultShell("Incomplete Maven Goal Execution");
 			new PushButton("OK").click();

--- a/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/QuickstartsTest.java
+++ b/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/QuickstartsTest.java
@@ -3,8 +3,12 @@ package org.jboss.tools.switchyard.ui.bot.test;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
 import org.jboss.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
 import org.jboss.reddeer.junit.requirement.inject.InjectRequirement;
@@ -53,16 +57,28 @@ public abstract class QuickstartsTest {
 
 		new ImportMavenWizard().importProject(fullPath);
 
-		checkErrors(path);
+		checkErrors(path, new FixableErrorMatcher());
 	}
 
 	protected void checkErrors(String path) {
+		checkErrors(path, null);
+	}
+	
+	protected void checkErrors(String path, Matcher<TreeItem> excludeMatcher) {
 		AbstractWait.sleep(TimePeriod.NORMAL);
 		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
 		
 		ErrorsExist errorsExistCondition = new ErrorsExist();
 		new WaitUntil(errorsExistCondition, TimePeriod.LONG, false);
-		List<TreeItem> errors = errorsExistCondition.getAllErrors();
+		List<TreeItem> allErrors = errorsExistCondition.getAllErrors();
+		List<TreeItem> errors = new ArrayList<TreeItem>();
+		for (TreeItem error: allErrors) {
+			if(excludeMatcher != null && excludeMatcher.matches(error)) {
+				continue;
+			}
+			errors.add(error);
+		}
+		
 		assertTrue("After importing the quickstart '" + path
 				+ "' there are the following errors:\n" + toString(errors), errors.isEmpty());
 	}
@@ -83,6 +99,27 @@ public abstract class QuickstartsTest {
 			result.append("\n");
 		}
 		return result.toString();
+	}
+	
+	private class FixableErrorMatcher extends BaseMatcher<TreeItem> {
+		
+		public static final String NOT_COVERED = "Plugin execution not covered by lifecycle configuration";
+
+		@Override
+		public boolean matches(Object obj) {
+			if (obj instanceof TreeItem) {
+				TreeItem treeItem = (TreeItem) obj;
+				String text = treeItem.getText();
+				return text != null && text.startsWith(NOT_COVERED);
+			}
+			return false;
+		}
+
+		@Override
+		public void describeTo(Description desc) {
+			
+		}
+		
 	}
 
 }

--- a/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/QuickstartsTest.java
+++ b/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/QuickstartsTest.java
@@ -5,22 +5,22 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.util.List;
 
-import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
-import org.jboss.reddeer.eclipse.jdt.ui.ProjectExplorer;
-import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.Project;
+import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
 import org.jboss.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
-import org.jboss.reddeer.eclipse.ui.problems.ProblemsView;
 import org.jboss.reddeer.junit.requirement.inject.InjectRequirement;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 import org.jboss.reddeer.swt.api.TreeItem;
 import org.jboss.reddeer.swt.condition.JobIsRunning;
+import org.jboss.reddeer.swt.handler.ShellHandler;
 import org.jboss.reddeer.swt.wait.AbstractWait;
 import org.jboss.reddeer.swt.wait.TimePeriod;
+import org.jboss.reddeer.swt.wait.WaitUntil;
 import org.jboss.reddeer.swt.wait.WaitWhile;
 import org.jboss.tools.runtime.reddeer.requirement.ServerReqType;
 import org.jboss.tools.runtime.reddeer.requirement.ServerRequirement.Server;
+import org.jboss.tools.switchyard.reddeer.condition.ErrorsExist;
 import org.jboss.tools.switchyard.reddeer.requirement.SwitchYardRequirement;
 import org.jboss.tools.switchyard.reddeer.requirement.SwitchYardRequirement.SwitchYard;
 import org.jboss.tools.switchyard.reddeer.wizard.ImportMavenWizard;
@@ -59,21 +59,21 @@ public abstract class QuickstartsTest {
 	protected void checkErrors(String path) {
 		AbstractWait.sleep(TimePeriod.NORMAL);
 		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
-
-		ProblemsView problemsView = new ProblemsView();
-		problemsView.open();
-		List<TreeItem> errors = problemsView.getAllErrors();
+		
+		ErrorsExist errorsExistCondition = new ErrorsExist();
+		new WaitUntil(errorsExistCondition, TimePeriod.LONG, false);
+		List<TreeItem> errors = errorsExistCondition.getAllErrors();
 		assertTrue("After importing the quickstart '" + path
 				+ "' there are the following errors:\n" + toString(errors), errors.isEmpty());
 	}
 
 	@After
 	public void deleteAllProjects() {
-		new SWTWorkbenchBot().closeAllShells();
-		ProjectExplorer projectExplorer = new ProjectExplorer();
-		for (Project project : projectExplorer.getProjects()) {
-			project.delete(false);
-		}
+		ShellHandler.getInstance().closeAllNonWorbenchShells();
+		
+		PackageExplorer packageExplorer = new PackageExplorer();
+		packageExplorer.open();
+		packageExplorer.deleteAllProjects(false);
 	}
 
 	protected String toString(List<TreeItem> items) {


### PR DESCRIPTION
Ignore errors such as 

Plugin execution not covered by lifecycle configuration ...