### PR TITLE
Fix memory options

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -14,7 +14,7 @@
   
         <properties>
             <surefire.timeout>7200</surefire.timeout>
-            <memoryOptions2>-XX:MaxPermSize=512m</memoryOptions2>
+            <memoryOptions2>-XX:MaxPermSize=384m</memoryOptions2>
             <swt.bot.test.record.screencast>false</swt.bot.test.record.screencast>
 	    <pauseFailedTest>false</pauseFailedTest>
             <integrationTestsSystemProperties>-Dswt.bot.test.record.screencast=${swt.bot.test.record.screencast} -Dorg.eclipse.swtbot.screenshots.dir=${project.build.directory}/screenshots -DpauseFailedTest=${pauseFailedTest}</integrationTestsSystemProperties>


### PR DESCRIPTION
Current memory options are
-Xms512m, -Xmx1024m, -XX:PermSize=256m, -XX:MaxPermSize=512m
which is too much for some 32b Windows OS
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
Error occurred during initialization of VM
Could not reserve enough space for object heap