### PR TITLE
Fuse: Fix regression test for FUSETOOLS-1123

### DIFF
--- a/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/RegressionTest.java
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/RegressionTest.java
@@ -265,11 +265,8 @@ public class RegressionTest {
 	/**
 	 * context id is removed on save
 	 * https://issues.jboss.org/browse/FUSETOOLS-1123
-	 * 
-	 * NOTE: not fixed yet -reopened
 	 */
 	@Test
-	@Ignore
 	public void issue_1123() {
 
 		ProjectFactory.createProject("camel-spring", "camel-archetype-spring");
@@ -279,7 +276,7 @@ public class RegressionTest {
 		CamelEditor.switchTab("Design");
 		CamelEditor.switchTab("Source");
 		String editorText = new DefaultStyledText().getText();
-		assertTrue(editorText.contains("id=id=\"test\""));
+		assertTrue(editorText.contains("id=\"test\""));
 	}
 
 	/**


### PR DESCRIPTION
1. test condition is wrong (`"id=id=\"test\""`)
2. do save of the editor