### PR TITLE
Fuse: Fix 'RouteManipulationTest'

### DIFF
--- a/plugins/org.jboss.tools.fuse.reddeer/src/org/jboss/tools/fuse/reddeer/utils/TracingDragAndDropManager.java
+++ b/plugins/org.jboss.tools.fuse.reddeer/src/org/jboss/tools/fuse/reddeer/utils/TracingDragAndDropManager.java
@@ -129,6 +129,7 @@ public class TracingDragAndDropManager {
 		log.debug("Tries to access 'To' item: " + from);
 		JMXNavigator jmx = new JMXNavigator();
 		jmx.open();
+		jmx.setShouldCollapseLocalProcesses(false);
 		return jmx.getNode(to);
 	}
 

--- a/plugins/org.jboss.tools.fuse.reddeer/src/org/jboss/tools/fuse/reddeer/view/JMXNavigator.java
+++ b/plugins/org.jboss.tools.fuse.reddeer/src/org/jboss/tools/fuse/reddeer/view/JMXNavigator.java
@@ -23,9 +23,21 @@ public class JMXNavigator extends WorkbenchView {
 
 	private static final Logger log = Logger.getLogger(JMXNavigator.class);
 
+	private boolean shouldCollapseLocalProcesses = true;
+
 	public JMXNavigator() {
 		super(TITLE);
 	}
+
+	public boolean isShouldCollapseLocalProcesses() {
+		return shouldCollapseLocalProcesses;
+	}
+
+
+	public void setShouldCollapseLocalProcesses(boolean shouldCollapseLocalProcesses) {
+		this.shouldCollapseLocalProcesses = shouldCollapseLocalProcesses;
+	}
+
 
 	/**
 	 * Tries to connect to a specified node under <i>Local Processes</i> in
@@ -85,7 +97,7 @@ public class JMXNavigator extends WorkbenchView {
 
 		for (TreeItem item : items) {
 			if (item.getText().equals("Local Processes")) {
-				item.collapse();
+				if (shouldCollapseLocalProcesses) item.collapse();
 				AbstractWait.sleep(TimePeriod.SHORT);
 				item.expand();
 				items = item.getItems();

--- a/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/RouteManipulationTest.java
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/RouteManipulationTest.java
@@ -106,8 +106,8 @@ public class RouteManipulationTest extends DefaultTest {
 		msg.open();
 		jmx.getNode("Local Camel Context", "Camel", "camel-1", "Endpoints", "file", "target/messages/others").select();
 		new TracingDragAndDropManager(from, to).performDragAndDrop();
-		jmx.getNode("Local Camel Context", "Camel", "camel-1", "Endpoints", "file", "target/messages/others").select();
 		new WaitUntil(new ConsoleHasText("INFO  Other message\n[1) thread #2 - file://src/data] route1                         INFO  UK message"), TimePeriod.getCustom(60));
+		jmx.getNode("Local Camel Context", "Camel", "camel-1", "Endpoints", "file", "target/messages/others").select();
 		new TracingDragAndDropManager(from2, to).performDragAndDrop();
 
 		msg = new MessagesView();


### PR DESCRIPTION
_RouteManipulationTest_ does not work, due to change in _JMXNavigator.getNode()_ method (which collapsing _Local Processes_ node).
=> Drag&Drop is broken