### PR TITLE
Drools: Smoke tests fail on macosx

### DIFF
--- a/tests/org.jboss.tools.drools.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.drools.ui.bot.test/pom.xml
@@ -48,6 +48,12 @@
               <artifactId>org.jbpm.eclipse.feature.feature.group</artifactId>
               <version>${plugin.version}</version>
             </dependency>
+	    <!-- This entry should enable creating of default JDK on Mac -->
+	    <dependency>
+	      <type>p2-installable-unit</type>
+	      <artifactId>org.eclipse.jdt.feature.group</artifactId>
+	      <version>0.0.0</version>
+	    </dependency>
           </dependencies>
         </configuration>
       </plugin>


### PR DESCRIPTION
This happens only if the tests are not executed against an existing instance of eclipse/jbds