### PR TITLE
Fuse: Fix 'RegressionTest'

### DIFF
--- a/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/RegressionTest.java
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/RegressionTest.java
@@ -228,9 +228,8 @@ public class RegressionTest extends DefaultTest {
 
 		ProjectFactory.createProject("camel-web", "camel-archetype-web");
 		new CamelProject("camel-web").runApplicationContextWithoutTests("applicationContext.xml");
-		new WaitUntil(new ConsoleHasText("[INFO] Started Jetty Server"), TimePeriod.LONG);
+		new WaitUntil(new ConsoleHasText("[INFO] Started Jetty Server"), TimePeriod.VERY_LONG);
 		new WaitUntil(new ConsoleHasText("Hello Web Application, how are you?"), TimePeriod.LONG);
-		
 	}
 
 	/**
@@ -308,6 +307,7 @@ public class RegressionTest extends DefaultTest {
 	public void issue_1132() throws FuseArchetypeNotFoundException {
 
 		ProjectFactory.createProject("camel-blueprint", "camel-archetype-blueprint");
+		new ProjectExplorer().getProject("camel-blueprint").getProjectItem("src/test/java", "com.mycompany.camel.blueprint", "RouteTest.java").delete();
 		String server = serverRequirement.getConfig().getName();
 		new BreakpointsView().importBreakpoints(ResourceHelper.getResourceAbsolutePath(Activator.PLUGIN_ID, "resources/breakpoint.bkpt"));
 		ServerManipulator.debugServer(server);


### PR DESCRIPTION
	at org.jboss.reddeer.swt.wait.AbstractWait.timeoutExceeded(AbstractWait.java:157)
	at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:110)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:75)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
	at org.jboss.reddeer.swt.wait.WaitUntil.<init>(WaitUntil.java:35)
	at org.jboss.tools.fuse.ui.bot.test.RegressionTest.issue_1077(RegressionTest.java:231)

issue_1085 fuse-620.xml(org.jboss.tools.fuse.ui.bot.test.RegressionTest)  Time elapsed: 34.857 sec
issue_1115 fuse-620.xml(org.jboss.tools.fuse.ui.bot.test.RegressionTest)  Time elapsed: 53.537 sec
issue_1123 fuse-620.xml(org.jboss.tools.fuse.ui.bot.test.RegressionTest)  Time elapsed: 49.579 sec
issue_1132 fuse-620.xml(org.jboss.tools.fuse.ui.bot.test.RegressionTest)  Time elapsed: 146.724 sec  <<< ERROR!
org.jboss.reddeer.swt.exception.SWTLayerException: No menu item matching specified path found
	at org.jboss.reddeer.swt.lookup.MenuLookup.lookFor(MenuLookup.java:159)
	at org.jboss.reddeer.swt.impl.menu.ShellMenu.<init>(ShellMenu.java:54)
	at org.jboss.reddeer.swt.impl.menu.ShellMenu.<init>(ShellMenu.java:46)
	at org.jboss.tools.fuse.reddeer.debug.SuspendButton.<init>(SuspendButton.java:14)
	at org.jboss.tools.fuse.reddeer.debug.IsRunning.test(IsRunning.java:17)
	at org.jboss.reddeer.swt.wait.WaitWhile.stopWaiting(WaitWhile.java:52)
	at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:106)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:75)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:39)
	at org.jboss.reddeer.swt.wait.WaitWhile.<init>(WaitWhile.java:22)
	at org.jboss.tools.fuse.ui.bot.test.RegressionTest.issue_1132(RegressionTest.java:324)

issue_1149 fuse-620.xml(org.jboss.tools.fuse.ui.bot.test.RegressionTest)  Time elapsed: 10.727 sec
issue_1152 fuse-620.xml(org.jboss.tools.fuse.ui.bot.test.RegressionTest)  Time elapsed: 275.687 sec  <<< ERROR!
org.jboss.reddeer.swt.exception.SWTLayerException: No control has focus. Perhaps something has stolen it? Try to regain focus with for example "new DefaultShell()".
	at org.jboss.reddeer.swt.lookup.MenuLookup.getTopMenuMenuItemsFromFocus(MenuLookup.java:175)
	at org.jboss.reddeer.swt.impl.menu.ContextMenu.<init>(ContextMenu.java:42)
	at org.jboss.reddeer.swt.impl.menu.ContextMenu.<init>(ContextMenu.java:33)
	at org.jboss.reddeer.eclipse.jdt.ui.AbstractExplorer.deleteAllProjects(AbstractExplorer.java:115)
	at org.jboss.reddeer.eclipse.jdt.ui.AbstractExplorer.deleteAllProjects(AbstractExplorer.java:103)
	at org.jboss.reddeer.eclipse.jdt.ui.AbstractExplorer.deleteAllProjects(AbstractExplorer.java:95)
	at org.jboss.tools.fuse.ui.bot.test.RegressionTest.clean(RegressionTest.java:92)

issue_1172 fuse-620.xml(org.jboss.tools.fuse.ui.bot.test.RegressionTest)  Time elapsed: 26.761 sec
issue_1252 fuse-620.xml(org.jboss.tools.fuse.ui.bot.test.RegressionTest)  Time elapsed: 109.205 sec  <<< ERROR!
org.jboss.reddeer.swt.exception.SWTLayerException: No matching widget found
	at org.jboss.reddeer.swt.wait.AbstractWait.timeoutExceeded(AbstractWait.java:157)
	at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:110)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:75)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:39)
	at org.jboss.reddeer.swt.wait.WaitUntil.<init>(WaitUntil.java:23)
	at org.jboss.reddeer.swt.lookup.WidgetLookup.activeWidget(WidgetLookup.java:71)
	at org.jboss.reddeer.swt.widgets.AbstractWidget.<init>(AbstractWidget.java:30)
	at org.jboss.reddeer.swt.impl.styledtext.AbstractStyledText.<init>(AbstractStyledText.java:24)
	at org.jboss.reddeer.swt.impl.styledtext.DefaultStyledText.<init>(DefaultStyledText.java:82)
	at org.jboss.reddeer.swt.impl.styledtext.DefaultStyledText.<init>(DefaultStyledText.java:28)
	at org.jboss.reddeer.swt.impl.styledtext.DefaultStyledText.<init>(DefaultStyledText.java:20)
	at org.jboss.reddeer.eclipse.ui.console.ConsoleView.getConsoleText(ConsoleView.java:42)
	at org.jboss.reddeer.eclipse.condition.ConsoleHasText.getConsoleText(ConsoleHasText.java:40)
	at org.jboss.reddeer.eclipse.condition.ConsoleHasText.test(ConsoleHasText.java:27)
	at org.jboss.reddeer.swt.wait.WaitUntil.stopWaiting(WaitUntil.java:55)
	at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:106)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:75)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
	at org.jboss.reddeer.swt.wait.WaitUntil.<init>(WaitUntil.java:35)
	at org.jboss.tools.fuse.reddeer.server.ServerManipulator.doOperation(ServerManipulator.java:158)
	at org.jboss.tools.fuse.reddeer.server.ServerManipulator.restartInDebug(ServerManipulator.java:133)
	at org.jboss.tools.fuse.ui.bot.test.RegressionTest.issue_1252(RegressionTest.java:404)


Results :

Tests in error: 
  RegressionTest.issue_1077:231 » WaitTimeoutExpired Timeout after: 60 s.: conso...
  RegressionTest.issue_1132:324 » SWTLayer No menu item matching specified path ...
  RegressionTest.clean:92 » SWTLayer No control has focus. Perhaps something has...
  RegressionTest.issue_1252:404 » SWTLayer No matching widget found

Tests run: 13, Failures: 0, Errors: 4, Skipped: 1
