### PR TITLE
Fuse: Fix 'ServerTest' (error log from Teiid plugin)

### DIFF
--- a/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/DefaultTest.java
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/DefaultTest.java
@@ -1,8 +1,11 @@
 package org.jboss.tools.fuse.ui.bot.test;
 
+import java.util.List;
+
 import org.jboss.reddeer.common.logging.Logger;
 import org.jboss.reddeer.eclipse.jdt.ui.ProjectExplorer;
 import org.jboss.reddeer.eclipse.ui.console.ConsoleView;
+import org.jboss.reddeer.eclipse.ui.views.log.LogMessage;
 import org.jboss.reddeer.swt.condition.JobIsRunning;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.swt.handler.ShellHandler;
@@ -96,5 +99,32 @@ public class DefaultTest {
 		log.info("Stopping and deleting configured servers");
 		ServerManipulator.deleteAllServers();
 		ServerManipulator.deleteAllServerRuntimes();
+	}
+
+	/**
+	 * Returns number of error messages in Error Log View originate from fuse plugins
+	 * 
+	 * @return number of error messages from fuse plugins
+	 */
+	protected int getErrorMessages() {
+
+		log.info("Receiving count of errors from fuse plugins");
+		int count = 0;
+		ErrorLogView errorLog = new ErrorLogView();
+		List<LogMessage> messages = errorLog.getErrorMessages();
+		for (LogMessage message : messages) {
+			if (message.getPlugin().toLowerCase().contains("fuse")) count++;
+		}
+		return count;
+	}
+
+	/**
+	 * Deletes Error Log
+	 */
+	protected void deleteErrorLog() {
+
+		log.info("Deleting error log");
+		ErrorLogView errorLog = new ErrorLogView();
+		errorLog.deleteLog();
 	}
 }

--- a/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/ServerTest.java
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/ServerTest.java
@@ -11,7 +11,6 @@ import org.jboss.reddeer.requirements.cleanworkspace.CleanWorkspaceRequirement.C
 import org.jboss.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 import org.jboss.tools.fuse.reddeer.server.ServerManipulator;
-import org.jboss.tools.fuse.reddeer.view.ErrorLogView;
 import org.jboss.tools.runtime.reddeer.impl.ServerFuse;
 import org.jboss.tools.runtime.reddeer.requirement.ServerReqType;
 import org.jboss.tools.runtime.reddeer.requirement.ServerRequirement;
@@ -45,24 +44,23 @@ public class ServerTest extends DefaultTest {
 	public void complexServerTest() {
 
 		ServerFuse fuse = (ServerFuse) serverRequirement.getConfig().getServerBase();
-		ErrorLogView errorLog = new ErrorLogView();
 
 		ServerManipulator.addServerRuntime(fuse.getName(), fuse.getHome());
-		assertEquals(1, ServerManipulator.getServerRuntimes().size());
+		assertEquals("New server runtime is not listed in Server Runtimes", 1, ServerManipulator.getServerRuntimes().size());
 		ServerManipulator.editServerRuntime(fuse.getName(), fuse.getHome());
 		ServerManipulator.addServer(fuse.getServerType(), fuse.getHost(), fuse.getName(), fuse.getPort(), fuse.getUsername(), fuse.getPassword());
-		assertEquals(1, ServerManipulator.getServers().size());
-		assertTrue(ServerManipulator.isServerPresent(fuse.getName()));
+		assertEquals("No server's record is in Servers View", 1, ServerManipulator.getServers().size());
+		assertTrue("New server is not listed in Servers View", ServerManipulator.isServerPresent(fuse.getName()));
 		ServerManipulator.startServer(fuse.getName());
-		assertTrue(ServerManipulator.isServerStarted(fuse.getName()));
-		assertTrue(errorLog.getErrorMessages().size() == 0);
-		errorLog.deleteLog();
+		assertTrue("Server is not started", ServerManipulator.isServerStarted(fuse.getName()));
+		assertTrue("There are some errors in error log", getErrorMessages() == 0);
+		deleteErrorLog();
 		ServerManipulator.stopServer(fuse.getName());
-		assertFalse(ServerManipulator.isServerStarted(fuse.getName()));
-		assertTrue(errorLog.getErrorMessages().size() == 0);
+		assertFalse("Server is not stopped", ServerManipulator.isServerStarted(fuse.getName()));
+		assertTrue("There are some errors in error log", getErrorMessages() == 0);
 		ServerManipulator.removeServer(fuse.getName());
-		assertEquals(0, ServerManipulator.getServers().size());
+		assertEquals("Server is listed in Servers View after deletion", 0, ServerManipulator.getServers().size());
 		ServerManipulator.removeServerRuntime(fuse.getName());
-		assertEquals(0, ServerManipulator.getServerRuntimes().size());
+		assertEquals("Server runtime is listed after deletion", 0, ServerManipulator.getServerRuntimes().size());
 	}
 }


### PR DESCRIPTION
Smoke Tests on JBDSIS cause failure, due to an error message from teiid designer plugin (see attached screenshot)

```
java.lang.AssertionError: null
	at org.junit.Assert.fail(Assert.java:86)
	at org.junit.Assert.assertTrue(Assert.java:41)
	at org.junit.Assert.assertTrue(Assert.java:52)
	at org.jboss.tools.fuse.ui.bot.test.ServerTest.complexServerTest(ServerTest.java:62)
```

![org jboss tools fuse ui bot test servertest complexservertest](https://cloud.githubusercontent.com/assets/5408450/8154662/b6b33a02-133c-11e5-83a5-e9b0cf011483.png)
