### PR TITLE
Fuse: Server is not started correctly

### DIFF
--- a/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/suite/SmokeTests.java
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/suite/SmokeTests.java
@@ -4,7 +4,6 @@ import junit.framework.TestSuite;
 
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.tools.fuse.ui.bot.test.ProjectLocalRunTest;
-import org.jboss.tools.fuse.ui.bot.test.ServerTest;
 import org.jboss.tools.fuse.ui.bot.test.SmokeTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite.SuiteClasses;
@@ -16,8 +15,7 @@ import org.junit.runners.Suite.SuiteClasses;
  */
 @SuiteClasses({
 		SmokeTest.class,
-		ProjectLocalRunTest.class,
-		ServerTest.class
+		ProjectLocalRunTest.class
 })
 @RunWith(RedDeerSuite.class)
 public class SmokeTests extends TestSuite {


### PR DESCRIPTION
Error Message

Server is not started

Stacktrace

java.lang.AssertionError: Server is not started
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.assertTrue(Assert.java:41)
	at org.jboss.tools.fuse.ui.bot.test.ServerTest.complexServerTest(ServerTest.java:55)


![screenshot from 2015-06-16 12-34-44](https://cloud.githubusercontent.com/assets/2270674/8181373/8b5c101a-1425-11e5-8e19-a68f71cc151b.png)
