### PR TITLE
Fuse: Extend current tests to accept other server types

### DIFF
--- a/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/DeploymentTest.java
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/DeploymentTest.java
@@ -29,7 +29,7 @@ import org.junit.runner.RunWith;
  * 
  * @author tsedmik
  */
-@Server(type = ServerReqType.Fuse, state = ServerReqState.PRESENT)
+@Server(type = {ServerReqType.Fuse, ServerReqType.Karaf, ServerReqType.ServiceMix}, state = ServerReqState.PRESENT)
 @CleanWorkspace
 @OpenPerspective(FuseIntegrationPerspective.class)
 @RunWith(RedDeerSuite.class)

--- a/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/JMXNavigatorServerTest.java
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/JMXNavigatorServerTest.java
@@ -43,7 +43,7 @@ import org.junit.runner.RunWith;
 @CleanWorkspace
 @OpenPerspective(FuseIntegrationPerspective.class)
 @RunWith(RedDeerSuite.class)
-@Server(type = ServerReqType.Fuse, state = ServerReqState.RUNNING)
+@Server(type = {ServerReqType.Fuse, ServerReqType.Karaf, ServerReqType.ServiceMix}, state = ServerReqState.RUNNING)
 public class JMXNavigatorServerTest {
 
 	private static final String PROJECT_ARCHETYPE = "camel-archetype-spring-dm";

--- a/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/ServerJRETest.java
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/ServerJRETest.java
@@ -12,14 +12,14 @@ import org.jboss.reddeer.requirements.server.ServerReqState;
 import org.jboss.reddeer.swt.impl.label.DefaultLabel;
 import org.jboss.tools.fuse.reddeer.perspectives.FuseIntegrationPerspective;
 import org.jboss.tools.fuse.reddeer.server.ServerManipulator;
-import org.jboss.tools.runtime.reddeer.impl.ServerFuse;
+import org.jboss.tools.runtime.reddeer.impl.ServerKaraf;
 import org.jboss.tools.runtime.reddeer.requirement.ServerReqType;
 import org.jboss.tools.runtime.reddeer.requirement.ServerRequirement;
 import org.jboss.tools.runtime.reddeer.requirement.ServerRequirement.Server;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-@Server(type = ServerReqType.Fuse, state = ServerReqState.PRESENT)
+@Server(type = {ServerReqType.Fuse, ServerReqType.Karaf, ServerReqType.ServiceMix}, state = ServerReqState.PRESENT)
 @OpenPerspective(FuseIntegrationPerspective.class)
 @CleanWorkspace
 @RunWith(RedDeerSuite.class)
@@ -31,10 +31,10 @@ public class ServerJRETest extends DefaultTest {
 	@Test
 	public void testJRE() {
 
-		ServerFuse fuse = (ServerFuse) serverRequirement.getConfig().getServerBase();
+		ServerKaraf fuse = (ServerKaraf) serverRequirement.getConfig().getServerBase();
 		assertNotNull("Different JRE is not specified!", fuse.getJre());
 		ServerManipulator.startServer(fuse.getName());
-		new ConsoleView().activate();
+		new ConsoleView().open();
 		assertTrue(new DefaultLabel().getText().contains(fuse.getJre()));
 	}
 }

--- a/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/ServerTest.java
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/ServerTest.java
@@ -11,7 +11,7 @@ import org.jboss.reddeer.requirements.cleanworkspace.CleanWorkspaceRequirement.C
 import org.jboss.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.jboss.reddeer.requirements.server.ServerReqState;
 import org.jboss.tools.fuse.reddeer.server.ServerManipulator;
-import org.jboss.tools.runtime.reddeer.impl.ServerFuse;
+import org.jboss.tools.runtime.reddeer.impl.ServerKaraf;
 import org.jboss.tools.runtime.reddeer.requirement.ServerReqType;
 import org.jboss.tools.runtime.reddeer.requirement.ServerRequirement;
 import org.jboss.tools.runtime.reddeer.requirement.ServerRequirement.Server;
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
  * 
  * @author tsedmik
  */
-@Server(type = ServerReqType.Fuse, state = ServerReqState.PRESENT)
+@Server(type = {ServerReqType.Fuse, ServerReqType.Karaf, ServerReqType.ServiceMix}, state = ServerReqState.PRESENT)
 @CleanWorkspace
 @OpenPerspective(JavaEEPerspective.class)
 @RunWith(RedDeerSuite.class)
@@ -43,7 +43,7 @@ public class ServerTest extends DefaultTest {
 	@Test
 	public void complexServerTest() {
 
-		ServerFuse fuse = (ServerFuse) serverRequirement.getConfig().getServerBase();
+		ServerKaraf fuse = (ServerKaraf) serverRequirement.getConfig().getServerBase();
 
 		ServerManipulator.addServerRuntime(fuse.getName(), fuse.getHome());
 		assertEquals("New server runtime is not listed in Server Runtimes", 1, ServerManipulator.getServerRuntimes().size());


### PR DESCRIPTION
Current tests accept only a Fuse server
`@Server(type = ServerReqType.Fuse, state = ServerReqState.PRESENT)`
change it to accept Apache Karaf server too
`@Server(type = {ServerReqType.Fuse, ServerReqType.Karaf}, state = ServerReqState.PRESENT)`