### PR TITLE
By default run tests without showing JBoss Central

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -17,7 +17,7 @@
             <memoryOptions2>-XX:MaxPermSize=384m</memoryOptions2>
             <swt.bot.test.record.screencast>false</swt.bot.test.record.screencast>
 	    <pauseFailedTest>false</pauseFailedTest>
-            <integrationTestsSystemProperties>-Dswt.bot.test.record.screencast=${swt.bot.test.record.screencast} -Dorg.eclipse.swtbot.screenshots.dir=${project.build.directory}/screenshots -DpauseFailedTest=${pauseFailedTest}</integrationTestsSystemProperties>
+            <integrationTestsSystemProperties>-Dswt.bot.test.record.screencast=${swt.bot.test.record.screencast} -Dorg.eclipse.swtbot.screenshots.dir=${project.build.directory}/screenshots -DpauseFailedTest=${pauseFailedTest} -Dorg.jboss.tools.central.donotshow=true</integrationTestsSystemProperties>
         </properties>
 
 	<modules>


### PR DESCRIPTION
You can disable JBoss Cebnral by 
```
-Dorg.jboss.tools.central.donotshow=true
```