### PR TITLE
SwitchYard: ImplementationsTest fails on Windows

### DIFF
--- a/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/wizard/ExistingServiceWizard.java
+++ b/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/wizard/ExistingServiceWizard.java
@@ -34,7 +34,7 @@ public abstract class ExistingServiceWizard<T extends ExistingServiceWizard<?>> 
 
 	@SuppressWarnings("unchecked")
 	public T activate() {
-		new WaitWhile(new JobIsRunning());
+		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
 		new DefaultShell(dialogTitle).setFocus();
 		AbstractWait.sleep(TimePeriod.SHORT);
 		return (T) this;
@@ -49,6 +49,11 @@ public abstract class ExistingServiceWizard<T extends ExistingServiceWizard<?>> 
 		new PushButton("OK").click();
 		new WaitWhile(new ShellWithTextIsActive(getSelectionDialogTitle()));
 		return activate();
+	}
+
+	@Override
+	public void finish() {
+		super.finish(TimePeriod.VERY_LONG);
 	}
 
 	protected abstract String getSelectionDialogTitle();

--- a/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/wizard/ServiceWizard.java
+++ b/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/wizard/ServiceWizard.java
@@ -28,7 +28,7 @@ import org.jboss.tools.switchyard.reddeer.editor.SwitchYardEditor;
 public abstract class ServiceWizard<T extends ServiceWizard<?>> extends WizardDialog {
 
 	private static Logger log = Logger.getLogger(SwitchYardEditor.class);
-	
+
 	private String dialogTitle;
 
 	public ServiceWizard() {
@@ -106,6 +106,11 @@ public abstract class ServiceWizard<T extends ServiceWizard<?>> extends WizardDi
 		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
 		new PushButton("OK").click();
 		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
+	}
+
+	@Override
+	public void finish() {
+		super.finish(TimePeriod.VERY_LONG);
 	}
 
 	protected abstract void browse();

--- a/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/ImplementationsTest.java
+++ b/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/ImplementationsTest.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 import org.jboss.reddeer.junit.requirement.inject.InjectRequirement;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.reddeer.swt.impl.button.NoButton;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.swt.impl.shell.WorkbenchShell;
 import org.jboss.tools.switchyard.reddeer.component.SwitchYardComponent;
 import org.jboss.tools.switchyard.reddeer.editor.SwitchYardEditor;
@@ -76,6 +78,13 @@ public class ImplementationsTest {
 
 	@After
 	public void deleteCreatedResousources() {
+		try {
+			new DefaultShell("Replace Current Implementation");
+			new NoButton().click();
+		} catch (Exception e) {
+			// ok
+		}
+
 		List<SwitchYardComponent> components = new SwitchYardEditor().getComponents();
 		while (!components.isEmpty()) {
 			components.get(0).delete();


### PR DESCRIPTION
org.jboss.reddeer.swt.exception.WaitTimeoutExpiredException: Timeout after: 10 s.: at least one job is running
	at org.jboss.reddeer.swt.wait.AbstractWait.timeoutExceeded(AbstractWait.java:157)
	at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:110)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:75)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:39)
	at org.jboss.reddeer.swt.wait.WaitWhile.<init>(WaitWhile.java:22)
	at org.jboss.tools.switchyard.reddeer.wizard.ExistingServiceWizard.activate(ExistingServiceWizard.java:37)
	at org.jboss.tools.switchyard.reddeer.wizard.ExistingServiceWizard.selectExistingImplementation(ExistingServiceWizard.java:51)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest.addExistingCamelXMLImplementationTest(ImplementationsTest.java:156)


org.jboss.reddeer.swt.exception.SWTLayerException: No matching widget found
	at org.jboss.reddeer.swt.wait.AbstractWait.timeoutExceeded(AbstractWait.java:157)
	at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:110)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:75)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:39)
	at org.jboss.reddeer.swt.wait.WaitUntil.<init>(WaitUntil.java:23)
	at org.jboss.reddeer.swt.lookup.WidgetLookup.activeWidget(WidgetLookup.java:71)
	at org.jboss.reddeer.swt.widgets.AbstractWidget.<init>(AbstractWidget.java:30)
	at org.jboss.reddeer.swt.impl.ctab.AbstractCTabItem.<init>(AbstractCTabItem.java:28)
	at org.jboss.reddeer.swt.impl.ctab.DefaultCTabItem.<init>(DefaultCTabItem.java:79)
	at org.jboss.reddeer.swt.impl.ctab.DefaultCTabItem.<init>(DefaultCTabItem.java:44)
	at org.jboss.reddeer.swt.impl.ctab.DefaultCTabItem.<init>(DefaultCTabItem.java:35)
	at org.jboss.tools.switchyard.reddeer.editor.SwitchYardEditor.activateDesignTab(SwitchYardEditor.java:78)
	at org.jboss.tools.switchyard.reddeer.editor.SwitchYardEditor.<init>(SwitchYardEditor.java:72)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest.deleteCreatedResousources(ImplementationsTest.java:79)


java.lang.AssertionError: The following shells remained open []
	at org.junit.Assert.fail(Assert.java:88)
	at org.jboss.reddeer.junit.extension.after.test.impl.CloseAllShellsExt.runAfterTest(CloseAllShellsExt.java:43)
	at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.runChild(RequirementsRunner.java:127)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.jboss.reddeer.junit.internal.runner.RunBefores.evaluate(RunBefores.java:80)
	at org.jboss.reddeer.junit.internal.runner.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:26)
	at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:64)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:108)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:208)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:156)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:82)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:91)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:73)
	at java.lang.Thread.run(Thread.java:745)