### PR TITLE
SwitchYard: Fix updating the project

### DIFF
--- a/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/wizard/SwitchYardProjectWizard.java
+++ b/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/wizard/SwitchYardProjectWizard.java
@@ -19,6 +19,7 @@ import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
 import org.jboss.reddeer.swt.keyboard.KeyboardFactory;
 import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitWhile;
+import org.jboss.tools.switchyard.reddeer.editor.SwitchYardEditor;
 import org.jboss.tools.switchyard.reddeer.project.SwitchYardProject;
 
 /**
@@ -258,6 +259,7 @@ public class SwitchYardProjectWizard extends NewWizardDialog {
 		}
 		selectComponents(components);
 		finish();
+		new SwitchYardEditor();
 		new SwitchYardProject(name).update();
 		if (targetRuntime != null && targetRuntime.contains("Karaf Extension")) {
 			new SwitchYardProject(name).enableFuseCamelNature();


### PR DESCRIPTION
Between creating and updating the project, the workbench shell title is changed due to opening a switchyard editor.

Error Message

Timeout after: 10 s.: shell with text matching"JBoss - JBoss Developer Studio" is active

Stacktrace

org.jboss.reddeer.swt.exception.WaitTimeoutExpiredException: Timeout after: 10 s.: shell with text matching"JBoss - JBoss Developer Studio" is active
	at org.jboss.reddeer.swt.wait.AbstractWait.timeoutExceeded(AbstractWait.java:157)
	at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:110)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:75)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:39)
	at org.jboss.reddeer.swt.wait.WaitUntil.<init>(WaitUntil.java:23)
	at org.jboss.reddeer.swt.impl.shell.AbstractShell.setFocus(AbstractShell.java:52)
	at org.jboss.reddeer.swt.impl.shell.WorkbenchShell.<init>(WorkbenchShell.java:23)
	at org.jboss.tools.switchyard.reddeer.project.SwitchYardProject.findTreeItem(SwitchYardProject.java:37)
	at org.jboss.tools.switchyard.reddeer.project.SwitchYardProject.<init>(SwitchYardProject.java:33)
	at org.jboss.tools.switchyard.reddeer.wizard.SwitchYardProjectWizard.create(SwitchYardProjectWizard.java:261)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest.createProject(ImplementationsTest.java:64)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.jboss.reddeer.junit.internal.runner.RunBefores.evaluate(RunBefores.java:50)
	at org.jboss.reddeer.junit.internal.runner.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:26)
	at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:64)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:108)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:208)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:156)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:82)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:91)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:73)
	at java.lang.Thread.run(Thread.java:745)
