### PR TITLE
SwitchYard: Improve stability of smoke tests

### DIFF
--- a/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/component/SwitchYardComponent.java
+++ b/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/component/SwitchYardComponent.java
@@ -1,13 +1,14 @@
 package org.jboss.tools.switchyard.reddeer.component;
 
-import org.jboss.reddeer.gef.editor.GEFEditor;
 import org.jboss.reddeer.graphiti.impl.graphitieditpart.AbstractGraphitiEditPart;
 import org.jboss.reddeer.swt.condition.JobIsRunning;
 import org.jboss.reddeer.swt.condition.ShellWithTextIsAvailable;
 import org.jboss.reddeer.swt.impl.button.PushButton;
+import org.jboss.reddeer.swt.impl.ctab.DefaultCTabItem;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitWhile;
+import org.jboss.reddeer.workbench.impl.editor.DefaultEditor;
 import org.jboss.tools.switchyard.reddeer.editor.SwitchYardEditor;
 import org.jboss.tools.switchyard.reddeer.matcher.WithTooltip;
 import org.jboss.tools.switchyard.reddeer.preference.CompositePropertiesPage;
@@ -32,7 +33,8 @@ public class SwitchYardComponent extends AbstractGraphitiEditPart {
 	 * @return the same index
 	 */
 	private static int activateSwitchYardEditor(int index) {
-		new GEFEditor(SwitchYardEditor.TITLE);
+		new DefaultEditor(SwitchYardEditor.TITLE);
+		new DefaultCTabItem("Design").activate();
 		return index;
 	}
 

--- a/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/condition/SwitchYardEditorIsOpen.java
+++ b/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/condition/SwitchYardEditorIsOpen.java
@@ -1,0 +1,28 @@
+package org.jboss.tools.switchyard.reddeer.condition;
+
+import org.jboss.reddeer.swt.condition.WaitCondition;
+import org.jboss.tools.switchyard.reddeer.editor.SwitchYardEditor;
+
+/**
+ * 
+ * @author apodhrad
+ *
+ */
+public class SwitchYardEditorIsOpen implements WaitCondition {
+
+	@Override
+	public boolean test() {
+		try {
+			new SwitchYardEditor();
+		} catch (Exception e) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public String description() {
+		return "SwitchYard editor is still unavailable.";
+	}
+
+}

--- a/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/editor/DomainEditor.java
+++ b/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/editor/DomainEditor.java
@@ -124,6 +124,7 @@ public class DomainEditor extends DefaultEditor {
 		if (name == null) {
 			throw new IllegalArgumentException("name is required, cannot be null");
 		}
+		wizard.activate();
 		wizard.setName(name);
 		if (rolesAllowed != null) {
 			wizard.setRolesAllowed(rolesAllowed);

--- a/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/preference/implementation/ImplementationKnowledgePage.java
+++ b/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/preference/implementation/ImplementationKnowledgePage.java
@@ -6,12 +6,12 @@ import org.jboss.reddeer.jface.preference.PreferencePage;
 import org.jboss.reddeer.swt.api.Button;
 import org.jboss.reddeer.swt.api.TableItem;
 import org.jboss.reddeer.swt.condition.ShellWithTextIsAvailable;
+import org.jboss.reddeer.swt.handler.ShellHandler;
 import org.jboss.reddeer.swt.impl.button.OkButton;
 import org.jboss.reddeer.swt.impl.button.PushButton;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.swt.impl.tab.DefaultTabItem;
 import org.jboss.reddeer.swt.impl.table.DefaultTable;
-import org.jboss.reddeer.swt.impl.table.DefaultTableItem;
 import org.jboss.reddeer.swt.impl.text.DefaultText;
 import org.jboss.reddeer.swt.matcher.RegexMatcher;
 import org.jboss.reddeer.swt.wait.WaitUntil;
@@ -152,7 +152,12 @@ public class ImplementationKnowledgePage extends PreferencePage {
 	private void addClass(CellEditor cellEditor, String title, String clazz) {
 		new PushButton(cellEditor, "...").click();
 		if (title != null) {
+			try {
 			new DefaultShell(title);
+			} catch (Exception e) {
+				ShellHandler.getInstance().closeAllNonWorbenchShells();
+				throw new RuntimeException("Cannot find a shell with title '" + title + "'", e);
+			}
 		} else {
 			new DefaultShell();
 		}

--- a/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/wizard/ExistingBPMNServiceWizard.java
+++ b/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/wizard/ExistingBPMNServiceWizard.java
@@ -12,7 +12,6 @@ import org.jboss.reddeer.swt.impl.group.DefaultGroup;
 import org.jboss.reddeer.swt.impl.text.LabeledText;
 import org.jboss.reddeer.swt.reference.ReferencedComposite;
 import org.jboss.reddeer.uiforms.impl.section.DefaultSection;
-import org.jboss.tools.switchyard.reddeer.widget.RadioButtonExt;
 
 /**
  * 
@@ -40,33 +39,42 @@ public class ExistingBPMNServiceWizard extends ExistingServiceWizard<ExistingBPM
 	}
 
 	public RadioButton getRemoteREST() {
-		return new RadioButtonExt("Remote REST");
+		return new RadioButton("Remote REST");
 	}
 
 	public RadioButton getRemoteJMS() {
-		return new RadioButtonExt("Remote JMS");
+		return new RadioButton("Remote JMS");
 	}
 
 	public RadioButton getKnowledgeContainer() {
-		return new RadioButtonExt("Knowledge Container");
+		return new RadioButton("Knowledge Container");
 	}
 
 	public RadioButton getProjectResource() {
-		return new RadioButtonExt("Project Resource");
+		return new RadioButton("Project Resource");
 	}
 
 	public ExistingBPMNServiceWizard selectRemoteREST() {
 		getRemoteREST().toggle(true);
+		if (!getRemoteREST().isSelected()) {
+			throw new RuntimeException("Cannot select Remote REST");
+		}
 		return this;
 	}
 
 	public ExistingBPMNServiceWizard selectRemoteJMS() {
 		getRemoteJMS().toggle(true);
+		if (!getRemoteJMS().isSelected()) {
+			throw new RuntimeException("Cannot select Remote JMS");
+		}
 		return this;
 	}
 
 	public ExistingBPMNServiceWizard selectKnowledgeContainer() {
 		getKnowledgeContainer().toggle(true);
+		if (!getKnowledgeContainer().isSelected()) {
+			throw new RuntimeException("Cannot select Knowledge Container");
+		}
 		return this;
 	}
 

--- a/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/wizard/SecurityConfigurationWizard.java
+++ b/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/wizard/SecurityConfigurationWizard.java
@@ -34,6 +34,7 @@ public class SecurityConfigurationWizard extends WizardDialog {
 	public void setName(String name) {
 		activate();
 		new LabeledText(NAME).typeText(name);
+		new LabeledText(NAME).setText(name);
 		new WaitUntil(new IsButtonEnabled("Finish", ROLES_ALLOWED, NAME), TimePeriod.LONG);
 	}
 

--- a/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/ImplementationsTest.java
+++ b/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/ImplementationsTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.jboss.reddeer.junit.requirement.inject.InjectRequirement;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.reddeer.swt.handler.ShellHandler;
 import org.jboss.reddeer.swt.impl.button.NoButton;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.swt.impl.shell.WorkbenchShell;
@@ -75,7 +76,9 @@ public class ImplementationsTest {
 
 	@AfterClass
 	public static void turnBackAutoBuilding() {
-		PreferenceUtils.setAutoBuilding(autoBuilding);
+		if (autoBuilding != null) {
+			PreferenceUtils.setAutoBuilding(autoBuilding);
+		}
 	}
 
 	@BeforeClass
@@ -101,6 +104,8 @@ public class ImplementationsTest {
 		} catch (Exception e) {
 			// ok
 		}
+		
+		ShellHandler.getInstance().closeAllNonWorbenchShells();
 
 		List<SwitchYardComponent> components = new SwitchYardEditor().getComponents();
 		while (!components.isEmpty()) {
@@ -350,7 +355,7 @@ public class ImplementationsTest {
 		bpmnWizard.getTruststoreLocation().setText("truststoreLoc");
 
 		bpmnWizard.finish();
-
+		
 		editor.save();
 		removeComponentAfterTest("Component");
 
@@ -474,7 +479,7 @@ public class ImplementationsTest {
 		droolsWizard.getScanInterval().setText("12345");
 
 		droolsWizard.finish();
-
+		
 		editor.save();
 		removeComponentAfterTest("Component");
 
@@ -504,7 +509,7 @@ public class ImplementationsTest {
 		droolsWizard.getUserName().setText("jmsAdmin");
 		droolsWizard.getPassword().setText("jmsAdmin123$");
 		droolsWizard.getTimeout().setText("123");
-
+		
 		droolsWizard.getUseSSL().setSelection("false");
 		Assert.assertFalse(droolsWizard.getKeystorePassword().isEnabled());
 		Assert.assertFalse(droolsWizard.getKeystoreLocation().isEnabled());
@@ -630,39 +635,33 @@ public class ImplementationsTest {
 	}
 
 	private void checkAdvancedProperties(String xpath, String tooltip) throws Exception {
-		try {
-			SwitchYardEditor editor = new SwitchYardEditor();
+		SwitchYardEditor editor = new SwitchYardEditor();
 
-			ImplementationKnowledgePage knowledgePage = new SwitchYardComponent(tooltip).showProperties()
-					.selectRulesImplementation();
-			knowledgePage.selectAdvanced();
-			knowledgePage.addChannel("myChannel", "myOperation", "myReference", "SwitchYardServiceChannel");
-			knowledgePage.addListener("AgendaStats");
-			knowledgePage.addLogger("CONSOLE", null, null);
-			knowledgePage.addProperty("prop", "val");
-			knowledgePage.ok();
+		ImplementationKnowledgePage knowledgePage = new SwitchYardComponent(tooltip).showProperties()
+				.selectRulesImplementation();
+		knowledgePage.selectAdvanced();
+		knowledgePage.addChannel("myChannel", "myOperation", "myReference", "SwitchYardServiceChannel");
+		knowledgePage.addListener("AgendaStats");
+		knowledgePage.addLogger("CONSOLE", null, null);
+		knowledgePage.addProperty("prop", "val");
+		knowledgePage.ok();
 
-			editor.save();
+		editor.save();
 
-			assertEquals("1", editor.xpath("count(" + xpath + "/channels)"));
-			assertEquals("myChannel", editor.xpath(xpath + "/channels/channel/@name"));
-			assertEquals("myOperation", editor.xpath(xpath + "/channels/channel/@operation"));
-			assertEquals("myReference", editor.xpath(xpath + "/channels/channel/@reference"));
-			assertEquals("org.switchyard.component.common.knowledge.service.SwitchYardServiceChannel",
-					editor.xpath(xpath + "/channels/channel/@class"));
-			assertEquals("1", editor.xpath("count(" + xpath + "/listeners)"));
-			assertEquals("org.drools.core.management.KieSessionMonitoringImpl$AgendaStats",
-					editor.xpath(xpath + "/listeners/listener/@class"));
-			assertEquals("1", editor.xpath("count(" + xpath + "/loggers)"));
-			assertEquals("CONSOLE", editor.xpath(xpath + "/loggers/logger/@type"));
-			assertEquals("1", editor.xpath("count(" + xpath + "/properties)"));
-			assertEquals("prop", editor.xpath(xpath + "/properties/property/@name"));
-			assertEquals("val", editor.xpath(xpath + "/properties/property/@value"));
-		} catch (Throwable e) {
-			e.printStackTrace();
-			System.out.println();
-		}
-		System.out.println();
+		assertEquals("1", editor.xpath("count(" + xpath + "/channels)"));
+		assertEquals("myChannel", editor.xpath(xpath + "/channels/channel/@name"));
+		assertEquals("myOperation", editor.xpath(xpath + "/channels/channel/@operation"));
+		assertEquals("myReference", editor.xpath(xpath + "/channels/channel/@reference"));
+		assertEquals("org.switchyard.component.common.knowledge.service.SwitchYardServiceChannel",
+				editor.xpath(xpath + "/channels/channel/@class"));
+		assertEquals("1", editor.xpath("count(" + xpath + "/listeners)"));
+		assertEquals("org.drools.core.management.KieSessionMonitoringImpl$AgendaStats",
+				editor.xpath(xpath + "/listeners/listener/@class"));
+		assertEquals("1", editor.xpath("count(" + xpath + "/loggers)"));
+		assertEquals("CONSOLE", editor.xpath(xpath + "/loggers/logger/@type"));
+		assertEquals("1", editor.xpath("count(" + xpath + "/properties)"));
+		assertEquals("prop", editor.xpath(xpath + "/properties/property/@name"));
+		assertEquals("val", editor.xpath(xpath + "/properties/property/@value"));
 	}
 
 	private void removeClassAfterTest(String className) {

--- a/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/suite/SmokeTests.java
+++ b/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/suite/SmokeTests.java
@@ -18,11 +18,11 @@ import org.junit.runners.Suite.SuiteClasses;
  *
  */
 @SuiteClasses({
-	HelloWorldTest.class,
+//	HelloWorldTest.class,
 	ImplementationsTest.class,
 	DomainSettingsTest.class,
 	ImplementationsPropertiesTest.class,
-	ValidatorsTest.class
+//	ValidatorsTest.class
 })
 @RunWith(RedDeerSuite.class)
 public class SmokeTests extends TestSuite {


### PR DESCRIPTION
This is from orion32

-------------------------------------------------------------------------------
Test set: org.jboss.tools.switchyard.ui.bot.test.suite.SmokeTests
-------------------------------------------------------------------------------
Tests run: 45, Failures: 4, Errors: 16, Skipped: 0, Time elapsed: 960.063 sec <<< FAILURE! - in org.jboss.tools.switchyard.ui.bot.test.suite.SmokeTests
helloWorldTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.HelloWorldTest)  Time elapsed: 208.69 sec
addExistingCamelXMLImplementationTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 12.966 sec
addDroolsImplementationWithNewJavaInterfaceTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 25.817 sec
addExistingDroolsImplementationWithRemoteRESTTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 32.04 sec  <<< ERROR!
org.jboss.reddeer.swt.exception.SWTLayerException: No matching widget found
	at org.jboss.reddeer.swt.wait.AbstractWait.timeoutExceeded(AbstractWait.java:157)
	at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:110)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:75)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:39)
	at org.jboss.reddeer.swt.wait.WaitUntil.<init>(WaitUntil.java:23)
	at org.jboss.reddeer.swt.lookup.WidgetLookup.activeWidget(WidgetLookup.java:71)
	at org.jboss.reddeer.swt.widgets.AbstractWidget.<init>(AbstractWidget.java:30)
	at org.jboss.reddeer.swt.impl.text.AbstractText.<init>(AbstractText.java:22)
	at org.jboss.reddeer.swt.impl.text.LabeledText.<init>(LabeledText.java:28)
	at org.jboss.reddeer.swt.impl.text.LabeledText.<init>(LabeledText.java:19)
	at org.jboss.tools.switchyard.reddeer.wizard.ExistingBPMNServiceWizard.getDeploymentID(ExistingBPMNServiceWizard.java:112)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest.addExistingDroolsImplementationWithRemoteRESTTest(ImplementationsTest.java:602)

addExistingDroolsImplementationWithRemoteRESTTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 32.059 sec  <<< ERROR!
org.jboss.reddeer.swt.exception.SWTLayerException: No matching widget found
	at org.jboss.reddeer.swt.wait.AbstractWait.timeoutExceeded(AbstractWait.java:157)
	at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:110)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:75)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:39)
	at org.jboss.reddeer.swt.wait.WaitUntil.<init>(WaitUntil.java:23)
	at org.jboss.reddeer.swt.lookup.WidgetLookup.activeWidget(WidgetLookup.java:71)
	at org.jboss.reddeer.swt.widgets.AbstractWidget.<init>(AbstractWidget.java:30)
	at org.jboss.reddeer.swt.impl.ctab.AbstractCTabItem.<init>(AbstractCTabItem.java:28)
	at org.jboss.reddeer.swt.impl.ctab.DefaultCTabItem.<init>(DefaultCTabItem.java:79)
	at org.jboss.reddeer.swt.impl.ctab.DefaultCTabItem.<init>(DefaultCTabItem.java:44)
	at org.jboss.reddeer.swt.impl.ctab.DefaultCTabItem.<init>(DefaultCTabItem.java:35)
	at org.jboss.tools.switchyard.reddeer.editor.SwitchYardEditor.activateDesignTab(SwitchYardEditor.java:79)
	at org.jboss.tools.switchyard.reddeer.editor.SwitchYardEditor.<init>(SwitchYardEditor.java:73)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest.deleteCreatedResousources(ImplementationsTest.java:101)

addExistingDroolsImplementationWithRemoteRESTTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 32.074 sec  <<< FAILURE!
java.lang.AssertionError: The following shells remained open []
	at org.junit.Assert.fail(Assert.java:88)
	at org.jboss.reddeer.junit.extension.after.test.impl.CloseAllShellsExt.runAfterTest(CloseAllShellsExt.java:43)
	at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.runChild(RequirementsRunner.java:127)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.jboss.reddeer.junit.internal.runner.RunBefores.evaluate(RunBefores.java:80)
	at org.jboss.reddeer.junit.internal.runner.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:26)
	at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:64)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:108)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:208)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:156)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:82)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:91)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:73)
	at java.lang.Thread.run(Thread.java:745)

addExistingDroolsImplementationWithRemoteJMSTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 20.853 sec  <<< ERROR!
org.jboss.reddeer.swt.exception.WaitTimeoutExpiredException: Timeout after: 10 s.: the number of edit parts is 3
	at org.jboss.reddeer.swt.wait.AbstractWait.timeoutExceeded(AbstractWait.java:157)
	at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:110)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:75)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:39)
	at org.jboss.reddeer.swt.wait.WaitUntil.<init>(WaitUntil.java:23)
	at org.jboss.tools.switchyard.reddeer.editor.SwitchYardEditor.addComponent(SwitchYardEditor.java:109)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest.addExistingDroolsImplementationWithRemoteJMSTest(ImplementationsTest.java:527)

addExistingBPMNImplementationWithRemoteRESTTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 31.245 sec  <<< ERROR!
org.jboss.reddeer.swt.exception.SWTLayerException: No matching widget found
	at org.jboss.reddeer.swt.wait.AbstractWait.timeoutExceeded(AbstractWait.java:157)
	at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:110)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:75)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:39)
	at org.jboss.reddeer.swt.wait.WaitUntil.<init>(WaitUntil.java:23)
	at org.jboss.reddeer.swt.lookup.WidgetLookup.activeWidget(WidgetLookup.java:71)
	at org.jboss.reddeer.swt.widgets.AbstractWidget.<init>(AbstractWidget.java:30)
	at org.jboss.reddeer.swt.impl.text.AbstractText.<init>(AbstractText.java:22)
	at org.jboss.reddeer.swt.impl.text.LabeledText.<init>(LabeledText.java:28)
	at org.jboss.reddeer.swt.impl.text.LabeledText.<init>(LabeledText.java:19)
	at org.jboss.tools.switchyard.reddeer.wizard.ExistingBPMNServiceWizard.getDeploymentID(ExistingBPMNServiceWizard.java:112)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest.addExistingBPMNImplementationWithRemoteRESTTest(ImplementationsTest.java:397)

addExistingBPMNImplementationWithRemoteRESTTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 31.264 sec  <<< ERROR!
org.jboss.reddeer.swt.exception.SWTLayerException: No matching widget found
	at org.jboss.reddeer.swt.wait.AbstractWait.timeoutExceeded(AbstractWait.java:157)
	at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:110)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:75)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:39)
	at org.jboss.reddeer.swt.wait.WaitUntil.<init>(WaitUntil.java:23)
	at org.jboss.reddeer.swt.lookup.WidgetLookup.activeWidget(WidgetLookup.java:71)
	at org.jboss.reddeer.swt.widgets.AbstractWidget.<init>(AbstractWidget.java:30)
	at org.jboss.reddeer.swt.impl.ctab.AbstractCTabItem.<init>(AbstractCTabItem.java:28)
	at org.jboss.reddeer.swt.impl.ctab.DefaultCTabItem.<init>(DefaultCTabItem.java:79)
	at org.jboss.reddeer.swt.impl.ctab.DefaultCTabItem.<init>(DefaultCTabItem.java:44)
	at org.jboss.reddeer.swt.impl.ctab.DefaultCTabItem.<init>(DefaultCTabItem.java:35)
	at org.jboss.tools.switchyard.reddeer.editor.SwitchYardEditor.activateDesignTab(SwitchYardEditor.java:79)
	at org.jboss.tools.switchyard.reddeer.editor.SwitchYardEditor.<init>(SwitchYardEditor.java:73)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest.deleteCreatedResousources(ImplementationsTest.java:101)

addExistingBPMNImplementationWithRemoteRESTTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 31.283 sec  <<< FAILURE!
java.lang.AssertionError: The following shells remained open []
	at org.junit.Assert.fail(Assert.java:88)
	at org.jboss.reddeer.junit.extension.after.test.impl.CloseAllShellsExt.runAfterTest(CloseAllShellsExt.java:43)
	at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.runChild(RequirementsRunner.java:127)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.jboss.reddeer.junit.internal.runner.RunBefores.evaluate(RunBefores.java:80)
	at org.jboss.reddeer.junit.internal.runner.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:26)
	at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:64)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:108)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:208)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:156)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:82)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:91)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:73)
	at java.lang.Thread.run(Thread.java:745)

addExistingDroolsImplementationWithKnowledgeContainerTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 20.752 sec  <<< ERROR!
org.jboss.reddeer.swt.exception.WaitTimeoutExpiredException: Timeout after: 10 s.: the number of edit parts is 3
	at org.jboss.reddeer.swt.wait.AbstractWait.timeoutExceeded(AbstractWait.java:157)
	at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:110)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:75)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:39)
	at org.jboss.reddeer.swt.wait.WaitUntil.<init>(WaitUntil.java:23)
	at org.jboss.tools.switchyard.reddeer.editor.SwitchYardEditor.addComponent(SwitchYardEditor.java:109)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest.addExistingDroolsImplementationWithKnowledgeContainerTest(ImplementationsTest.java:485)

addBPMNImplementationWithNewJavaInterfaceTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 22.425 sec
addExistingDroolsImplementationTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 13.793 sec
addExistingBPMNImplementationWithRemoteJMSTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 31.211 sec  <<< ERROR!
org.jboss.reddeer.swt.exception.SWTLayerException: No matching widget found
	at org.jboss.reddeer.swt.wait.AbstractWait.timeoutExceeded(AbstractWait.java:157)
	at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:110)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:75)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:39)
	at org.jboss.reddeer.swt.wait.WaitUntil.<init>(WaitUntil.java:23)
	at org.jboss.reddeer.swt.lookup.WidgetLookup.activeWidget(WidgetLookup.java:71)
	at org.jboss.reddeer.swt.widgets.AbstractWidget.<init>(AbstractWidget.java:30)
	at org.jboss.reddeer.swt.impl.text.AbstractText.<init>(AbstractText.java:22)
	at org.jboss.reddeer.swt.impl.text.LabeledText.<init>(LabeledText.java:28)
	at org.jboss.reddeer.swt.impl.text.LabeledText.<init>(LabeledText.java:19)
	at org.jboss.tools.switchyard.reddeer.wizard.ExistingBPMNServiceWizard.getDeploymentID(ExistingBPMNServiceWizard.java:112)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest.addExistingBPMNImplementationWithRemoteJMSTest(ImplementationsTest.java:328)

addExistingBPMNImplementationWithRemoteJMSTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 31.218 sec  <<< ERROR!
org.jboss.reddeer.swt.exception.SWTLayerException: No matching widget found
	at org.jboss.reddeer.swt.wait.AbstractWait.timeoutExceeded(AbstractWait.java:157)
	at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:110)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:75)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:39)
	at org.jboss.reddeer.swt.wait.WaitUntil.<init>(WaitUntil.java:23)
	at org.jboss.reddeer.swt.lookup.WidgetLookup.activeWidget(WidgetLookup.java:71)
	at org.jboss.reddeer.swt.widgets.AbstractWidget.<init>(AbstractWidget.java:30)
	at org.jboss.reddeer.swt.impl.ctab.AbstractCTabItem.<init>(AbstractCTabItem.java:28)
	at org.jboss.reddeer.swt.impl.ctab.DefaultCTabItem.<init>(DefaultCTabItem.java:79)
	at org.jboss.reddeer.swt.impl.ctab.DefaultCTabItem.<init>(DefaultCTabItem.java:44)
	at org.jboss.reddeer.swt.impl.ctab.DefaultCTabItem.<init>(DefaultCTabItem.java:35)
	at org.jboss.tools.switchyard.reddeer.editor.SwitchYardEditor.activateDesignTab(SwitchYardEditor.java:79)
	at org.jboss.tools.switchyard.reddeer.editor.SwitchYardEditor.<init>(SwitchYardEditor.java:73)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest.deleteCreatedResousources(ImplementationsTest.java:101)

addExistingBPMNImplementationWithRemoteJMSTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 31.227 sec  <<< FAILURE!
java.lang.AssertionError: The following shells remained open []
	at org.junit.Assert.fail(Assert.java:88)
	at org.jboss.reddeer.junit.extension.after.test.impl.CloseAllShellsExt.runAfterTest(CloseAllShellsExt.java:43)
	at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.runChild(RequirementsRunner.java:127)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.jboss.reddeer.junit.internal.runner.RunBefores.evaluate(RunBefores.java:80)
	at org.jboss.reddeer.junit.internal.runner.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:26)
	at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:64)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:108)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:208)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:156)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:82)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:91)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:73)
	at java.lang.Thread.run(Thread.java:745)

addExistingBPMNImplementationWithKnowledgeContainerTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 20.845 sec  <<< ERROR!
org.jboss.reddeer.swt.exception.WaitTimeoutExpiredException: Timeout after: 10 s.: the number of edit parts is 3
	at org.jboss.reddeer.swt.wait.AbstractWait.timeoutExceeded(AbstractWait.java:157)
	at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:110)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:75)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:39)
	at org.jboss.reddeer.swt.wait.WaitUntil.<init>(WaitUntil.java:23)
	at org.jboss.tools.switchyard.reddeer.editor.SwitchYardEditor.addComponent(SwitchYardEditor.java:109)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest.addExistingBPMNImplementationWithKnowledgeContainerTest(ImplementationsTest.java:284)

addBPELImplementationWithNewWSDLInterfaceTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 22.628 sec
addExistingBPMNImplementationTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 13.039 sec
addBeanImplementationWithNewJavaInterfaceTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 24.192 sec
addCamelJavaImplementationWithNewJavaInterfaceTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 23.415 sec
addExistingBPELImplementationTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 12.88 sec
addCamelXMLImplementationWithNewJavaInterfaceTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest)  Time elapsed: 22.146 sec
securityConfigurationTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.DomainSettingsTest)  Time elapsed: 7.999 sec  <<< ERROR!
java.lang.RuntimeException: Cannot find security configuration 'test-security'
	at org.jboss.tools.switchyard.reddeer.editor.DomainEditor.getSecurityConfiguration(DomainEditor.java:181)
	at org.jboss.tools.switchyard.ui.bot.test.DomainSettingsTest.securityConfigurationTest(DomainSettingsTest.java:147)

messageTraceTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.DomainSettingsTest)  Time elapsed: 3.468 sec
filePropertiesTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.DomainSettingsTest)  Time elapsed: 6 sec
propertiesTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.DomainSettingsTest)  Time elapsed: 3.25 sec
implementationSecurityPolicyTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsPropertiesTest)  Time elapsed: 1.609 sec
implementationTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsPropertiesTest)  Time elapsed: 0.188 sec
contractTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsPropertiesTest)  Time elapsed: 0.203 sec
resourceTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsPropertiesTest)  Time elapsed: 0.281 sec
componentPropertiesTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsPropertiesTest)  Time elapsed: 3.375 sec
contractTransactionPolicyTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsPropertiesTest)  Time elapsed: 1.234 sec
contractSecurityPolicyTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsPropertiesTest)  Time elapsed: 77.125 sec  <<< ERROR!
org.jboss.reddeer.swt.exception.WaitTimeoutExpiredException: Timeout after: 60 s.: Button 'Finish' was not enabled!
	at org.jboss.reddeer.swt.wait.AbstractWait.timeoutExceeded(AbstractWait.java:157)
	at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:110)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:75)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
	at org.jboss.reddeer.swt.wait.WaitUntil.<init>(WaitUntil.java:35)
	at org.jboss.tools.switchyard.reddeer.wizard.SecurityConfigurationWizard.setName(SecurityConfigurationWizard.java:37)
	at org.jboss.tools.switchyard.reddeer.editor.DomainEditor.addSecurityConfiguration(DomainEditor.java:127)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsPropertiesTest.contractSecurityPolicyTest(ImplementationsPropertiesTest.java:206)

contractSecurityPolicyTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsPropertiesTest)  Time elapsed: 77.125 sec  <<< ERROR!
org.jboss.reddeer.swt.exception.SWTLayerException: SWT Shell passed to constructor is null
	at org.jboss.reddeer.swt.impl.shell.AbstractShell.<init>(AbstractShell.java:32)
	at org.jboss.reddeer.swt.impl.shell.DefaultShell.<init>(DefaultShell.java:17)
	at org.jboss.tools.switchyard.reddeer.preference.CompositePropertiesPage.activate(CompositePropertiesPage.java:33)
	at org.jboss.tools.switchyard.reddeer.preference.CompositePropertiesPage.ok(CompositePropertiesPage.java:132)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsPropertiesTest.closeProperties(ImplementationsPropertiesTest.java:105)

contractSecurityPolicyTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsPropertiesTest)  Time elapsed: 77.125 sec  <<< FAILURE!
java.lang.AssertionError: The following shells remained open [Security Configuration]
	at org.junit.Assert.fail(Assert.java:88)
	at org.jboss.reddeer.junit.extension.after.test.impl.CloseAllShellsExt.runAfterTest(CloseAllShellsExt.java:43)
	at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.runChild(RequirementsRunner.java:127)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.jboss.reddeer.junit.internal.runner.RunBefores.evaluate(RunBefores.java:80)
	at org.jboss.reddeer.junit.internal.runner.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:26)
	at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:64)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:108)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:208)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:156)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:82)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:91)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:73)
	at java.lang.Thread.run(Thread.java:745)

implementationTransactionPolicyTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsPropertiesTest)  Time elapsed: 0.172 sec  <<< ERROR!
org.jboss.reddeer.gef.GEFLayerException: Cannot find graphical viewer in a given editor part
	at org.jboss.reddeer.gef.lookup.ViewerLookup.findGraphicalViewer(ViewerLookup.java:58)
	at org.jboss.reddeer.gef.editor.GEFEditor.initGraphicalViewer(GEFEditor.java:55)
	at org.jboss.reddeer.gef.editor.GEFEditor.<init>(GEFEditor.java:48)
	at org.jboss.tools.switchyard.reddeer.component.SwitchYardComponent.activateSwitchYardEditor(SwitchYardComponent.java:35)
	at org.jboss.tools.switchyard.reddeer.component.SwitchYardComponent.<init>(SwitchYardComponent.java:24)
	at org.jboss.tools.switchyard.reddeer.component.SwitchYardComponent.<init>(SwitchYardComponent.java:20)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsPropertiesTest.openProperties(ImplementationsPropertiesTest.java:100)

implementationTransactionPolicyTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsPropertiesTest)  Time elapsed: 0.172 sec  <<< ERROR!
java.lang.NullPointerException: null
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsPropertiesTest.closeProperties(ImplementationsPropertiesTest.java:105)

componentTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsPropertiesTest)  Time elapsed: 0.157 sec  <<< ERROR!
org.jboss.reddeer.gef.GEFLayerException: Cannot find graphical viewer in a given editor part
	at org.jboss.reddeer.gef.lookup.ViewerLookup.findGraphicalViewer(ViewerLookup.java:58)
	at org.jboss.reddeer.gef.editor.GEFEditor.initGraphicalViewer(GEFEditor.java:55)
	at org.jboss.reddeer.gef.editor.GEFEditor.<init>(GEFEditor.java:48)
	at org.jboss.tools.switchyard.reddeer.component.SwitchYardComponent.activateSwitchYardEditor(SwitchYardComponent.java:35)
	at org.jboss.tools.switchyard.reddeer.component.SwitchYardComponent.<init>(SwitchYardComponent.java:24)
	at org.jboss.tools.switchyard.reddeer.component.SwitchYardComponent.<init>(SwitchYardComponent.java:20)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsPropertiesTest.openProperties(ImplementationsPropertiesTest.java:100)

componentTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ImplementationsPropertiesTest)  Time elapsed: 0.172 sec  <<< ERROR!
java.lang.NullPointerException: null
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsPropertiesTest.closeProperties(ImplementationsPropertiesTest.java:105)

validatorJavaBeanTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ValidatorsTest)  Time elapsed: 14.187 sec
validatorXMLSchemaTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ValidatorsTest)  Time elapsed: 15.235 sec
validatorRelaxNGTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ValidatorsTest)  Time elapsed: 13.578 sec
validatorDTDTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ValidatorsTest)  Time elapsed: 13.406 sec
validatorJavaClassTest switchyard-200.xml(org.jboss.tools.switchyard.ui.bot.test.ValidatorsTest)  Time elapsed: 13.313 sec
