### PR TITLE
BPEL: Fix AssociateRuntimeTest

### DIFF
--- a/tests/org.jboss.tools.bpel.ui.bot.test/src/org/jboss/tools/bpel/ui/bot/test/AssociateRuntimeTest.java
+++ b/tests/org.jboss.tools.bpel.ui.bot.test/src/org/jboss/tools/bpel/ui/bot/test/AssociateRuntimeTest.java
@@ -48,8 +48,8 @@ public class AssociateRuntimeTest {
 
 		new DefaultTreeItem("Targeted Runtimes").select();
 
-		String serverName = serverRequirement.getConfig().getName();
-		assertTrue(containsItem(new DefaultTable(), serverName));
+		String runtimeName = serverRequirement.getConfig().getName() + " Runtime";
+		assertTrue(containsItem(new DefaultTable(), runtimeName));
 
 		new PushButton("OK").click();
 		


### PR DESCRIPTION
There was a change in naming runtime and server. Now, each runtime must ends with " Runtime".