### PR TITLE
SwitchYard: Increase timeout when waiting on a class

### DIFF
--- a/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/condition/TableHasRow.java
+++ b/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/condition/TableHasRow.java
@@ -1,5 +1,6 @@
 package org.jboss.tools.switchyard.reddeer.condition;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.hamcrest.Matcher;
@@ -11,16 +12,18 @@ public class TableHasRow implements WaitCondition {
 
 	private Table table;
 	private Matcher<String> matcher;
+	private List<TableItem> items;
 
 	public TableHasRow(Table table, Matcher<String> matcher) {
 		this.table = table;
 		this.matcher = matcher;
+		this.items = new ArrayList<TableItem>();
 	}
-	
+
 	@Override
 	public boolean test() {
-		List<TableItem> items = table.getItems();
-		for (TableItem item: items) {
+		items = table.getItems();
+		for (TableItem item : items) {
 			if (matcher.matches(item.getText())) {
 				item.select();
 				return true;
@@ -31,7 +34,12 @@ public class TableHasRow implements WaitCondition {
 
 	@Override
 	public String description() {
-		return null;
+		StringBuffer message = new StringBuffer();
+		message.append("an item matching ").append(matcher.toString()).append(" in\n");
+		for (TableItem item : items) {
+			message.append("\t").append(item.getText()).append("\n");
+		}
+		return message.toString();
 	}
 
 }

--- a/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/preference/implementation/ImplementationKnowledgePage.java
+++ b/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/preference/implementation/ImplementationKnowledgePage.java
@@ -14,6 +14,7 @@ import org.jboss.reddeer.swt.impl.tab.DefaultTabItem;
 import org.jboss.reddeer.swt.impl.table.DefaultTable;
 import org.jboss.reddeer.swt.impl.text.DefaultText;
 import org.jboss.reddeer.swt.matcher.RegexMatcher;
+import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitUntil;
 import org.jboss.reddeer.swt.wait.WaitWhile;
 import org.jboss.reddeer.uiforms.impl.section.DefaultSection;
@@ -153,7 +154,7 @@ public class ImplementationKnowledgePage extends PreferencePage {
 		new PushButton(cellEditor, "...").click();
 		if (title != null) {
 			try {
-			new DefaultShell(title);
+				new DefaultShell(title);
 			} catch (Exception e) {
 				ShellHandler.getInstance().closeAllNonWorbenchShells();
 				throw new RuntimeException("Cannot find a shell with title '" + title + "'", e);
@@ -162,7 +163,7 @@ public class ImplementationKnowledgePage extends PreferencePage {
 			new DefaultShell();
 		}
 		new DefaultText().setText(clazz);
-		new WaitUntil(new TableHasRow(new DefaultTable(), new RegexMatcher(".*" + clazz + ".*")));
+		new WaitUntil(new TableHasRow(new DefaultTable(), new RegexMatcher(".*" + clazz + ".*")), TimePeriod.LONG);
 		new OkButton().click();
 		if (title != null) {
 			new WaitWhile(new ShellWithTextIsAvailable(title));


### PR DESCRIPTION
org.jboss.reddeer.swt.exception.WaitTimeoutExpiredException: Timeout after: 10 s.: null
	at org.jboss.reddeer.swt.wait.AbstractWait.timeoutExceeded(AbstractWait.java:157)
	at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:110)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:75)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:39)
	at org.jboss.reddeer.swt.wait.WaitUntil.<init>(WaitUntil.java:23)
	at org.jboss.tools.switchyard.reddeer.preference.implementation.ImplementationKnowledgePage.addClass(ImplementationKnowledgePage.java:165)
	at org.jboss.tools.switchyard.reddeer.preference.implementation.ImplementationKnowledgePage.addItem(ImplementationKnowledgePage.java:141)
	at org.jboss.tools.switchyard.reddeer.preference.implementation.ImplementationKnowledgePage.addChannel(ImplementationKnowledgePage.java:94)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest.checkAdvancedProperties(ImplementationsTest.java:643)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest.checkDroolsAdvancedProperties(ImplementationsTest.java:634)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest.addDroolsImplementationWithNewJavaInterfaceTest(ImplementationsTest.java:434)