### PR TITLE
BPMN2: Cannot build org.jboss.tools.bpmn2.ui.bot.test

### DIFF
--- a/tests/org.jboss.tools.bpmn2.ui.bot.test/pom.xml
+++ b/tests/org.jboss.tools.bpmn2.ui.bot.test/pom.xml
@@ -151,6 +151,7 @@
 					<outputDirectory>lib</outputDirectory>
 					<excludeTransitive>false</excludeTransitive>
 					<excludeScope>system</excludeScope>
+					<skip>false</skip>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
Because maven-dependency-plugin:copy-dependencies is skipped, so there are not libraries in the folder lib. I have no idea why it is skipped (and only on jbtis-4.3.x).