### PR TITLE
Fuse: Fix failing 'SmokeTests'

### DIFF
--- a/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/suite/SmokeTests.java
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/suite/SmokeTests.java
@@ -1,14 +1,12 @@
 package org.jboss.tools.fuse.ui.bot.test.suite;
 
-import junit.framework.TestSuite;
-
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
-import org.jboss.tools.fuse.ui.bot.test.JMXNavigatorTest;
 import org.jboss.tools.fuse.ui.bot.test.ProjectLocalRunTest;
-import org.jboss.tools.fuse.ui.bot.test.ServerTest;
 import org.jboss.tools.fuse.ui.bot.test.SmokeTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite.SuiteClasses;
+
+import junit.framework.TestSuite;
 
 /**
  * Runs smoke tests on Fuse Tooling
@@ -16,9 +14,7 @@ import org.junit.runners.Suite.SuiteClasses;
  * @author tsedmik
  */
 @SuiteClasses({
-		JMXNavigatorTest.class,
 		ProjectLocalRunTest.class,
-		ServerTest.class,
 		SmokeTest.class
 })
 @RunWith(RedDeerSuite.class)


### PR DESCRIPTION
Windows

```
INFO [WorkbenchTestable][JMXNavigator] Child items of 'Local Processes' are: 
c:\hudson\slave.jar [2472][Disconnected]
Eclipse Runtime Workbench [2328][Disconnected]
maven [2088][Disconnected]
maven [3048][Disconnected]

INFO [WorkbenchTestable][JMXNavigator] Trying to identify the right process
INFO [WorkbenchTestable][JMXNavigator] Looking for 'Local Camel Context' item
INFO [WorkbenchTestable][AbstractTreeItem] Select tree item maven [2088][Disconnected]
INFO [WorkbenchTestable][TreeItemHandler] Selected tree item: maven [2088][Disconnected]
INFO [WorkbenchTestable][AbstractTreeItem] Double click tree item maven [2088][Disconnected]
INFO [WorkbenchTestable][AbstractTreeItem] Select tree item maven [2088][Disconnected]
INFO [WorkbenchTestable][TreeItemHandler] Selected tree item: maven [2088][Disconnected]
INFO [WorkbenchTestable][JMXNavigator] Trying to expand 'maven [2088][Disconnected]' Tree Item
INFO [WorkbenchTestable][AbstractTreeItem] Expand tree item maven [2088][Disconnected] and wait with time period 1
INFO [WorkbenchTestable][TreeItemHandler] Expanded: maven [2088][Disconnected]
ERROR [WorkbenchTestable][JMXNavigator] Tree Item 'maven [2088][Disconnected]' is NOT expanded!
INFO [WorkbenchTestable][JMXNavigator] Trying to expand 'maven [2088][Disconnected]' Tree Item
INFO [WorkbenchTestable][AbstractTreeItem] Expand tree item maven [2088][Disconnected] and wait with time period 1
INFO [WorkbenchTestable][TreeItemHandler] Expanded: maven [2088][Disconnected]
ERROR [WorkbenchTestable][JMXNavigator] Tree Item 'maven [2088][Disconnected]' is NOT expanded!
INFO [WorkbenchTestable][JMXNavigator] Trying to expand 'maven [2088][Disconnected]' Tree Item
INFO [WorkbenchTestable][AbstractTreeItem] Expand tree item maven [2088][Disconnected] and wait with time period 1
INFO [WorkbenchTestable][TreeItemHandler] Expanded: maven [2088][Disconnected]
ERROR [WorkbenchTestable][JMXNavigator] Tree Item 'maven [2088][Disconnected]' is NOT expanded!
INFO [WorkbenchTestable][JMXNavigator] Trying to expand 'maven [2088][Disconnected]' Tree Item
INFO [WorkbenchTestable][AbstractTreeItem] Expand tree item maven [2088][Disconnected] and wait with time period 1
INFO [WorkbenchTestable][TreeItemHandler] Expanded: maven [2088][Disconnected]
INFO [WorkbenchTestable][JMXNavigator] Tree Item 'maven [2088][Connected]' is expanded
INFO [WorkbenchTestable][AbstractTreeItem] Expand tree item maven [2088][Connected] and wait with time period 1
INFO [WorkbenchTestable][TreeItemHandler] Expanded: maven [2088][Connected]
INFO [WorkbenchTestable][TreeItemHandler] Expanded: maven [2088][Connected]
INFO [WorkbenchTestable][AbstractTreeItem] Select tree item maven [3048][Disconnected]
INFO [WorkbenchTestable][TreeItemHandler] Selected tree item: maven [3048][Disconnected]
INFO [WorkbenchTestable][AbstractTreeItem] Double click tree item maven [3048][Disconnected]
INFO [WorkbenchTestable][AbstractTreeItem] Select tree item maven [3048][Disconnected]
INFO [WorkbenchTestable][TreeItemHandler] Selected tree item: maven [3048][Disconnected]
INFO [WorkbenchTestable][JMXNavigator] Trying to expand 'maven [3048][Disconnected]' Tree Item
INFO [WorkbenchTestable][AbstractTreeItem] Expand tree item maven [3048][Disconnected] and wait with time period 1
INFO [WorkbenchTestable][TreeItemHandler] Expanded: maven [3048][Disconnected]
ERROR [WorkbenchTestable][JMXNavigator] Tree Item 'maven [3048][Disconnected]' is NOT expanded!
INFO [WorkbenchTestable][JMXNavigator] Trying to expand 'maven [3048][Disconnected]' Tree Item
INFO [WorkbenchTestable][AbstractTreeItem] Expand tree item maven [3048][Disconnected] and wait with time period 1
INFO [WorkbenchTestable][TreeItemHandler] Expanded: maven [3048][Disconnected]
INFO [WorkbenchTestable][JMXNavigator] Tree Item 'maven [3048][Disconnected]' is expanded
INFO [WorkbenchTestable][AbstractTreeItem] Expand tree item maven [3048][Connected] and wait with time period 1
INFO [WorkbenchTestable][TreeItemHandler] Expanded: maven [3048][Connected]
INFO [WorkbenchTestable][TreeItemHandler] Expanded: maven [3048][Connected]
WARNING [WorkbenchTestable][JMXNavigator] 'Local Camel Context' item was NOT found
INFO [WorkbenchTestable][JMXNavigator] Looking for 'Camel'
ERROR [WorkbenchTestable][RequirementsRunner] Test org.jboss.tools.fuse.ui.bot.test.JMXNavigatorTest.processesViewTest throws exception: 

java.lang.NullPointerException: null
	at org.jboss.tools.fuse.reddeer.view.JMXNavigator.getNode(JMXNavigator.java:124)
	at org.jboss.tools.fuse.ui.bot.test.JMXNavigatorTest.processesViewTest(JMXNavigatorTest.java:66)
```

Windows

```
org.jboss.reddeer.swt.exception.WaitTimeoutExpiredException: Timeout after: 60 s.: at least one job is running
	at org.jboss.reddeer.swt.wait.AbstractWait.timeoutExceeded(AbstractWait.java:157)
	at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:110)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:75)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
	at org.jboss.reddeer.swt.wait.WaitWhile.<init>(WaitWhile.java:33)
	at org.jboss.reddeer.jface.wizard.WizardDialog.finish(WizardDialog.java:123)
	at org.jboss.reddeer.jface.wizard.WizardDialog.finish(WizardDialog.java:108)
	at org.jboss.tools.runtime.reddeer.impl.ServerKaraf.create(ServerKaraf.java:141)
	at org.jboss.tools.runtime.reddeer.requirement.ServerRequirement.fulfill(ServerRequirement.java:80)
	at org.jboss.reddeer.junit.internal.requirement.Requirements.fulfill(Requirements.java:74)
	at org.jboss.reddeer.junit.internal.runner.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:25)
	at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:64)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:108)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:208)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:156)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:82)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:91)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:73)
	at java.lang.Thread.run(Thread.java:745)
```

RHEL

```
org.jboss.reddeer.swt.exception.SWTLayerException: Exception during sync execution in UI thread
	at org.jboss.reddeer.swt.util.Display.syncExec(Display.java:82)
	at org.jboss.reddeer.swt.util.ObjectUtil.invokeMethodUI(ObjectUtil.java:62)
	at org.jboss.reddeer.swt.util.ObjectUtil.invokeMethod(ObjectUtil.java:43)
	at org.jboss.reddeer.swt.util.ObjectUtil.invokeMethod(ObjectUtil.java:27)
	at org.jboss.reddeer.swt.handler.WidgetHandler.getText(WidgetHandler.java:144)
	at org.jboss.reddeer.swt.impl.tree.AbstractTreeItem.getText(AbstractTreeItem.java:52)
	at org.jboss.tools.fuse.reddeer.view.JMXNavigator.getNode(JMXNavigator.java:103)
	at org.jboss.tools.fuse.ui.bot.test.JMXNavigatorTest.processesViewTest(JMXNavigatorTest.java:66)
Caused by: org.jboss.reddeer.swt.exception.SWTLayerException: Exception when invoking method public java.lang.String org.eclipse.swt.widgets.TreeItem.getText() by reflection
	at org.jboss.reddeer.swt.util.ObjectUtil.invokeMethod(ObjectUtil.java:74)
	at org.jboss.reddeer.swt.util.ObjectUtil.access$0(ObjectUtil.java:70)
	at org.jboss.reddeer.swt.util.ObjectUtil$1.run(ObjectUtil.java:65)
	at org.jboss.reddeer.swt.util.Display$ErrorHandlingRunnable.run(Display.java:150)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:136)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:3774)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3412)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$9.run(PartRenderingEngine.java:1151)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1032)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:148)
	at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:636)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:579)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:150)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:135)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:120)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:380)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:235)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:648)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:603)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1465)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1438)
Caused by: java.lang.reflect.InvocationTargetException: null
	at sun.reflect.GeneratedMethodAccessor46.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.jboss.reddeer.swt.util.ObjectUtil.invokeMethod(ObjectUtil.java:72)
	at org.jboss.reddeer.swt.util.ObjectUtil.access$0(ObjectUtil.java:70)
	at org.jboss.reddeer.swt.util.ObjectUtil$1.run(ObjectUtil.java:65)
	at org.jboss.reddeer.swt.util.Display$ErrorHandlingRunnable.run(Display.java:150)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:136)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:3774)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3412)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$9.run(PartRenderingEngine.java:1151)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1032)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:148)
	at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:636)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:579)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:150)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:135)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:120)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:380)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:235)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:648)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:603)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1465)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1438)
Caused by: org.eclipse.swt.SWTException: Widget is disposed
	at org.eclipse.swt.SWT.error(SWT.java:4441)
	at org.eclipse.swt.SWT.error(SWT.java:4356)
	at org.eclipse.swt.SWT.error(SWT.java:4327)
	at org.eclipse.swt.widgets.Widget.error(Widget.java:476)
	at org.eclipse.swt.widgets.Widget.checkWidget(Widget.java:413)
	at org.eclipse.swt.widgets.TreeItem.getText(TreeItem.java:842)
	at sun.reflect.GeneratedMethodAccessor46.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.jboss.reddeer.swt.util.ObjectUtil.invokeMethod(ObjectUtil.java:72)
	at org.jboss.reddeer.swt.util.ObjectUtil.access$0(ObjectUtil.java:70)
	at org.jboss.reddeer.swt.util.ObjectUtil$1.run(ObjectUtil.java:65)
	at org.jboss.reddeer.swt.util.Display$ErrorHandlingRunnable.run(Display.java:150)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:136)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:3774)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3412)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$9.run(PartRenderingEngine.java:1151)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1032)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:148)
	at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:636)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:579)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:150)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:135)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:120)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:380)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:235)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:648)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:603)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1465)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1438)
```