### PR TITLE
Runtime: Adopt WildFly change from JBT 4.3.0.CR1

### DIFF
--- a/plugins/org.jboss.tools.runtime.reddeer/src/org/jboss/tools/runtime/reddeer/impl/ServerWildFly.java
+++ b/plugins/org.jboss.tools.runtime.reddeer/src/org/jboss/tools/runtime/reddeer/impl/ServerWildFly.java
@@ -24,12 +24,12 @@ public class ServerWildFly extends ServerAS {
 
 	@Override
 	public String getServerType() {
-		return label + " " + getVersion();
+		return label + "  " + getVersion();
 	}
 
 	@Override
 	public String getRuntimeType() {
-		return label + " " + getVersion() + " Runtime";
+		return label + "  " + getVersion() + " Runtime";
 	}
 
 }


### PR DESCRIPTION
The label in server creation wizard was changes as follows

"Wildfly 8.x" to "Wildfly  8.x" (two whitespaces), see https://issues.jboss.org/browse/JBIDE-20548