### PR TITLE
Unify build.properties files

### DIFF
--- a/plugins/org.jboss.tools.bpel.reddeer/build.properties
+++ b/plugins/org.jboss.tools.bpel.reddeer/build.properties
@@ -1,4 +1,4 @@
 source.. = src/
-output.. = bin/
+output.. = target/classes
 bin.includes = META-INF/,\
                .

--- a/plugins/org.jboss.tools.bpmn2.reddeer/build.properties
+++ b/plugins/org.jboss.tools.bpmn2.reddeer/build.properties
@@ -1,5 +1,5 @@
 source.. = src/,\
            resources/
-output.. = bin/
+output.. = target/classes
 bin.includes = META-INF/,\
                .

--- a/plugins/org.jboss.tools.esb.reddeer/build.properties
+++ b/plugins/org.jboss.tools.esb.reddeer/build.properties
@@ -1,4 +1,4 @@
 source.. = src/
-output.. = bin/
+output.. = target/classes
 bin.includes = META-INF/,\
                .

--- a/plugins/org.jboss.tools.modeshape.reddeer/build.properties
+++ b/plugins/org.jboss.tools.modeshape.reddeer/build.properties
@@ -1,4 +1,4 @@
 source.. = src/
-output.. = bin/
+output.. = target/classes
 bin.includes = META-INF/,\
                .

--- a/plugins/org.jboss.tools.teiid.reddeer/build.properties
+++ b/plugins/org.jboss.tools.teiid.reddeer/build.properties
@@ -1,4 +1,4 @@
 source.. = src/
-output.. = bin/
+output.. = target/classes
 bin.includes = META-INF/,\
                .

--- a/tests/org.jboss.tools.bpel.ui.bot.test/build.properties
+++ b/tests/org.jboss.tools.bpel.ui.bot.test/build.properties
@@ -1,5 +1,5 @@
 source.. = src/
-output.. = bin/
+output.. = target/classes
 bin.includes = .,\
                META-INF/,\
 	       resources/,\

--- a/tests/org.jboss.tools.bpmn2.ui.bot.test/build.properties
+++ b/tests/org.jboss.tools.bpmn2.ui.bot.test/build.properties
@@ -1,6 +1,6 @@
 source.. = src/,\
            resources/
-output.. = bin/
+output.. = target/classes
 bin.includes = META-INF/,\
                .,\
                lib/drools-compiler.jar,\

--- a/tests/org.jboss.tools.modeshape.ui.bot.test/build.properties
+++ b/tests/org.jboss.tools.modeshape.ui.bot.test/build.properties
@@ -1,5 +1,5 @@
 source.. = src/
-output.. = bin/
+output.. = target/classes
 bin.includes = .,\
                META-INF/,\
 	       resources/

--- a/tests/org.jboss.tools.teiid.ui.bot.test/build.properties
+++ b/tests/org.jboss.tools.teiid.ui.bot.test/build.properties
@@ -1,5 +1,5 @@
 source.. = src/
-output.. = bin/
+output.. = target/classes
 bin.includes = .,\
                resources/,\
                META-INF/


### PR DESCRIPTION
Unify build.properties files so that they specify
```
output.. = target/classes
```