### PR TITLE
Fuse: Fix CamelEditor problem with 'save()' method

### DIFF
--- a/plugins/org.jboss.tools.fuse.reddeer/src/org/jboss/tools/fuse/reddeer/editor/CamelEditor.java
+++ b/plugins/org.jboss.tools.fuse.reddeer/src/org/jboss/tools/fuse/reddeer/editor/CamelEditor.java
@@ -10,9 +10,11 @@ import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.part.FileEditorInput;
+import org.jboss.reddeer.common.exception.WaitTimeoutExpiredException;
 import org.jboss.reddeer.common.logging.Logger;
 import org.jboss.reddeer.common.wait.AbstractWait;
 import org.jboss.reddeer.common.wait.TimePeriod;
+import org.jboss.reddeer.common.wait.WaitUntil;
 import org.jboss.reddeer.core.condition.ShellWithTextIsAvailable;
 import org.jboss.reddeer.core.exception.CoreLayerException;
 import org.jboss.reddeer.core.util.Display;
@@ -26,9 +28,11 @@ import org.jboss.reddeer.gef.impl.editpart.LabeledEditPart;
 import org.jboss.reddeer.gef.view.PaletteView;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.swt.impl.button.PushButton;
+import org.jboss.reddeer.swt.impl.button.YesButton;
 import org.jboss.reddeer.swt.impl.combo.DefaultCombo;
 import org.jboss.reddeer.swt.impl.ctab.DefaultCTabItem;
 import org.jboss.reddeer.swt.impl.menu.ContextMenu;
+import org.jboss.reddeer.swt.impl.menu.ShellMenu;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.swt.impl.styledtext.DefaultStyledText;
 import org.jboss.reddeer.swt.impl.text.DefaultText;
@@ -54,15 +58,27 @@ public class CamelEditor extends GEFEditor {
 		super(title);
 	}
 
-	
 	@Override
 	public void save() {
 		activate();
 		click(1, 1);
 		new ContextMenu("Layout Diagram").select();
-		super.save();
+		new ShellMenu("File", "Save").select();
+		try {
+			new WaitUntil(new ShellWithTextIsAvailable("Please confirm..."));
+			new DefaultShell("Please confirm...");
+			new YesButton().click();
+			throw new CamelEditorException("There are unconnected endpoints in the diagram!");
+		} catch (WaitTimeoutExpiredException e) {
+			// The dialog "Please confirm..." didn't show up => everything is OK
+		}
 	}
 
+	@Override
+	public void close() {
+		save();
+		super.close();
+	}
 
 	/**
 	 * Adds a component into the Camel Editor at given position
@@ -315,7 +331,7 @@ public class CamelEditor extends GEFEditor {
 	}
 
 	/**
-	 * Switchs between 'Design' and 'Source' tab of the Camel Editor
+	 * Switches between 'Design' and 'Source' tab of the Camel Editor
 	 * 
 	 * @param name
 	 *            'Design' or 'Source'

--- a/plugins/org.jboss.tools.fuse.reddeer/src/org/jboss/tools/fuse/reddeer/editor/CamelEditorException.java
+++ b/plugins/org.jboss.tools.fuse.reddeer/src/org/jboss/tools/fuse/reddeer/editor/CamelEditorException.java
@@ -1,0 +1,10 @@
+package org.jboss.tools.fuse.reddeer.editor;
+
+public class CamelEditorException extends RuntimeException {
+
+	private static final long serialVersionUID = 7429922555705581038L;
+
+	public CamelEditorException(String message) {
+		super(message);
+	}
+}

--- a/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/CamelEditorTest.java
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/CamelEditorTest.java
@@ -2,6 +2,7 @@ package org.jboss.tools.fuse.ui.bot.test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.List;
 
@@ -21,6 +22,7 @@ import org.jboss.tools.fuse.reddeer.component.Generic;
 import org.jboss.tools.fuse.reddeer.component.Log;
 import org.jboss.tools.fuse.reddeer.component.Otherwise;
 import org.jboss.tools.fuse.reddeer.editor.CamelEditor;
+import org.jboss.tools.fuse.reddeer.editor.CamelEditorException;
 import org.jboss.tools.fuse.reddeer.editor.SourceEditor;
 import org.jboss.tools.fuse.reddeer.projectexplorer.CamelProject;
 import org.jboss.tools.fuse.reddeer.view.ErrorLogView;
@@ -171,6 +173,11 @@ public class CamelEditorTest extends DefaultTest {
 		editor.doOperation("log", "Add", "Components", "Generic");
 		editor.setComboProperty("Endpoint", 0, "file:target/messages/others");
 		editor.setId("log1", "");
+		try {
+			editor.save();
+		} catch (CamelEditorException e) {
+			fail("There are unconnected endpoints in the diagram");
+		}
 		assertTrue(editor.isComponentAvailable("otherwise"));
 		assertTrue(editor.isComponentAvailable("file:target/messa..."));
 		CamelEditor.switchTab("Source");
@@ -201,19 +208,31 @@ public class CamelEditorTest extends DefaultTest {
 		CamelEditor editor = new CamelEditor("camel-context.xml");
 		editor.addCamelComponent(new Otherwise(), 0, -100);
 		editor.addConnection("choice", "otherwise");
-		editor.save();
+		try {
+			editor.save();
+		} catch (CamelEditorException e) {
+			fail("Connection between 'choice' and 'otherwise' wasn't created");
+		}
 		AbstractWait.sleep(TimePeriod.SHORT);
 		editor.setId("log", "log1");
 		editor.setId("file:target/messa...", "temp");
 		editor.addCamelComponent(new Log());
 		editor.setProperty("log", "Message", "Other message");
 		editor.addConnection("otherwise", "log");
-		editor.save();
+		try {
+			editor.save();
+		} catch (CamelEditorException e) {
+			fail("Connection between 'otherwise' and 'log' wasn't created");
+		}
 		AbstractWait.sleep(TimePeriod.getCustom(1));
 		editor.addCamelComponent(new Generic());
 		editor.setComboProperty("Endpoint", 0, "file:target/messages/others");
 		editor.addConnection("log", "file:target/messa...");
-		editor.save();
+		try {
+			editor.save();
+		} catch (CamelEditorException e) {
+			fail("Connection between 'log' and 'file:target/messa...' wasn't created");
+		}
 		AbstractWait.sleep(TimePeriod.getCustom(1));
 		editor.setId("temp", "");
 		editor.setId("log1", "");


### PR DESCRIPTION
In tests may occur a situation where in Camel Editor are unconnected endpoints. If this situation happen, test freeze (waits until saving of editor is performed, but additional dialog "Please confirm..." is shown up).