### PR TITLE
Teiid: TimeoutException in BasicTest

### DIFF
--- a/tests/org.jboss.tools.teiid.ui.bot.test/src/org/jboss/tools/teiid/ui/bot/test/BasicTest.java
+++ b/tests/org.jboss.tools.teiid.ui.bot.test/src/org/jboss/tools/teiid/ui/bot/test/BasicTest.java
@@ -29,6 +29,7 @@ public class BasicTest {
 
 	@BeforeClass
 	public static void prepare() {
+		teiidBot.uncheckBuildAutomatically();
 		new ModelExplorerManager().createProject(PROJECT);
 		Properties props = new Properties();
 		props.setProperty("local", "true");

--- a/tests/org.jboss.tools.teiid.ui.bot.test/src/org/jboss/tools/teiid/ui/bot/test/ModelWizardTest.java
+++ b/tests/org.jboss.tools.teiid.ui.bot.test/src/org/jboss/tools/teiid/ui/bot/test/ModelWizardTest.java
@@ -41,9 +41,11 @@ public class ModelWizardTest {
 	public static final String WEBSERVICE_MODEL_NAME = "webservice_view";
 	public static final String MODELEXT_MODEL_NAME = "modelext";
 	public static final String FUNCTION_MODEL_NAME = "function_userdef";
+	private static TeiidBot teiidBot = new TeiidBot();
 
 	@BeforeClass
 	public static void beforeClass() {
+		teiidBot.uncheckBuildAutomatically();
 		new ModelExplorerManager().createProject(PROJECT_NAME);
 	}
 


### PR DESCRIPTION
Error Message

Timeout after: 60 s.: at least one job is running

Stacktrace

org.jboss.reddeer.common.exception.WaitTimeoutExpiredException: Timeout after: 60 s.: at least one job is running
	at org.jboss.reddeer.common.wait.AbstractWait.timeoutExceeded(AbstractWait.java:159)
	at org.jboss.reddeer.common.wait.AbstractWait.wait(AbstractWait.java:112)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:77)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:53)
	at org.jboss.reddeer.common.wait.WaitWhile.<init>(WaitWhile.java:35)
	at org.jboss.reddeer.jface.wizard.WizardDialog.finish(WizardDialog.java:136)
	at org.jboss.reddeer.jface.wizard.WizardDialog.finish(WizardDialog.java:121)
	at org.jboss.tools.teiid.reddeer.wizard.ModelProjectWizard.create(ModelProjectWizard.java:37)
	at org.jboss.tools.teiid.reddeer.manager.ModelExplorerManager.createProject(ModelExplorerManager.java:46)
	at org.jboss.tools.teiid.ui.bot.test.BasicTest.prepare(BasicTest.java:32)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.jboss.reddeer.junit.internal.runner.RunBefores.evaluate(RunBefores.java:50)
	at org.jboss.reddeer.junit.internal.runner.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:26)
	at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:64)
	at org.jboss.reddeer.junit.internal.runner.CleanUpRequirementStatement.evaluate(CleanUpRequirementStatement.java:25)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:110)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:208)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:156)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:82)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:91)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:73)
	at java.lang.Thread.run(Thread.java:745)
