### PR TITLE
Fuse: Correct wrong names of methods

### DIFF
--- a/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/FuseProjectTest.java
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/FuseProjectTest.java
@@ -55,7 +55,7 @@ public class FuseProjectTest extends DefaultTest {
 	 * @return List of all available Fuse project archetypes
 	 */
 	@Parameters
-	public static Collection<String> data() {
+	public static Collection<String> setupData() {
 		return ProjectFactory.getArchetypes();
 	}
 

--- a/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/LicenseTest.java
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/LicenseTest.java
@@ -48,7 +48,7 @@ public class LicenseTest {
 	 * @return List of all available Fuse plugins
 	 */
 	@Parameters
-	public static Collection<String> data() {
+	public static Collection<String> setupData() {
 		new ShellMenu("Help", "Installation Details").select();
 		new DefaultShell("JBoss Developer Studio Installation Details");
 		new DefaultTabItem("Installed Software").activate();

--- a/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/QuickStartsTest.java
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/QuickStartsTest.java
@@ -61,7 +61,7 @@ public class QuickStartsTest {
 	 * Prepares test environment
 	 */
 	@Before
-	public void defaultSetup() {
+	public void setupDefault() {
 
 		new WorkbenchShell();
 		new ErrorLogView().deleteLog();

--- a/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/RegressionKarafTest.java
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/RegressionKarafTest.java
@@ -41,7 +41,7 @@ public class RegressionKarafTest extends DefaultTest {
 	 * Cleans up test environment
 	 */
 	@After
-	public void steupClean() {
+	public void setupClean() {
 
 		String server = serverRequirement.getConfig().getName();
 		if (FuseServerManipulator.isServerStarted(server)) {


### PR DESCRIPTION
* FuseProjectTest - data()
* LicenseTest - data()
* QuickStartsTest - defaultSetup()
* RegressionKarafTest - steupClean()

Convention:
* test methods --> test*
* auxiliary methods (Before, After, Parameters, ...) --> setup*