### PR TITLE
Teiid: Fix 'ModelWizardTest'

### DIFF
--- a/plugins/org.jboss.tools.runtime.reddeer/resources/SOARequirements.xsd
+++ b/plugins/org.jboss.tools.runtime.reddeer/resources/SOARequirements.xsd
@@ -83,6 +83,7 @@
 					</xs:element>
 					<xs:element name="targetRuntime" type="xs:string" minOccurs="0" />
 					<xs:element name="libraryVersion" type="xs:string" />
+					<xs:element name="componentRestriction" type="xs:string" minOccurs="0" />
 					<xs:choice minOccurs="0">
 						<xs:element name="karaf" type="server:apache-karaf" />
 						<xs:element name="servicemix" type="server:apache-servicemix" />

--- a/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/requirement/SwitchYardConfig.java
+++ b/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/requirement/SwitchYardConfig.java
@@ -23,6 +23,8 @@ public class SwitchYardConfig extends ServerConfig {
 	private String targetRuntime;
 	@XmlElement(name = "libraryVersion", namespace = Namespaces.SOA_REQ)
 	private String libraryVersion;
+	@XmlElement(name = "componentRestriction", namespace = Namespaces.SOA_REQ)
+	private String componentRestriction;
 
 	public String getConfigurationVersion() {
 		return configurationVersion;
@@ -46,6 +48,14 @@ public class SwitchYardConfig extends ServerConfig {
 
 	public void setLibraryVersion(String libraryVersion) {
 		this.libraryVersion = libraryVersion;
+	}
+
+	public String getComponentRestriction() {
+		return componentRestriction;
+	}
+
+	public void setComponentRestriction(String componentRestriction) {
+		this.componentRestriction = componentRestriction;
 	}
 
 }

--- a/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/requirement/SwitchYardRequirement.java
+++ b/plugins/org.jboss.tools.switchyard.reddeer/src/org/jboss/tools/switchyard/reddeer/requirement/SwitchYardRequirement.java
@@ -41,8 +41,7 @@ public class SwitchYardRequirement implements Requirement<SwitchYard>, CustomCon
 
 		String libraryVersion() default SwitchYardProjectWizard.DEFAULT_LIBRARY_VERSION;
 
-		Server server() default @Server(type = {}, state = ServerReqState.PRESENT)
-		;
+		Server server() default @Server(type = {}, state = ServerReqState.PRESENT);
 	}
 
 	@Override

--- a/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/SwitchYardEditorImplementationsTest.java
+++ b/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/SwitchYardEditorImplementationsTest.java
@@ -43,8 +43,8 @@ import org.jboss.tools.switchyard.reddeer.wizard.ExistingBPMNServiceWizard;
 import org.jboss.tools.switchyard.reddeer.wizard.ExistingCamelXMLServiceWizard;
 import org.jboss.tools.switchyard.reddeer.wizard.ExistingDroolsServiceWizard;
 import org.jboss.tools.switchyard.reddeer.wizard.ImportFileWizard;
-import org.jboss.tools.switchyard.ui.bot.test.condition.IssueIsClosed;
-import org.jboss.tools.switchyard.ui.bot.test.condition.IssueIsClosed.Jira;
+import org.jboss.tools.switchyard.ui.bot.test.condition.SwitchYardRequirementSupportBPMN;
+import org.jboss.tools.switchyard.ui.bot.test.condition.SwitchYardRequirementSupportDrools;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -73,7 +73,7 @@ public class SwitchYardEditorImplementationsTest {
 	private static int index = 0;
 
 	@InjectRequirement
-	private static SwitchYardRequirement switchYardRequirement;
+	private static SwitchYardRequirement switchyardRequirement;
 
 	private static String autoBuilding;
 
@@ -101,7 +101,7 @@ public class SwitchYardEditorImplementationsTest {
 
 	@BeforeClass
 	public static void createProject() {
-		switchYardRequirement.project(PROJECT_NAME).implAll().create();
+		switchyardRequirement.project(PROJECT_NAME).implAll().create();
 
 		new SwitchYardProject(PROJECT_NAME).getProjectItem("src/main/resources").select();
 		new ImportFileWizard().importFile("resources/" + PROJECT_NAME);
@@ -266,6 +266,7 @@ public class SwitchYardEditorImplementationsTest {
 	}
 
 	@Test
+	@RunIf(conditionClass = SwitchYardRequirementSupportBPMN.class)
 	public void addBPMNImplementationWithNewJavaInterfaceTest() throws Exception {
 		SwitchYardEditor editor = new SwitchYardEditor();
 		BPMNServiceWizard bpmnWizard = editor.addBPMNImplementation();
@@ -292,6 +293,7 @@ public class SwitchYardEditorImplementationsTest {
 	}
 
 	@Test
+	@RunIf(conditionClass = SwitchYardRequirementSupportBPMN.class)
 	public void addExistingBPMNImplementationTest() throws Exception {
 		SwitchYardEditor editor = new SwitchYardEditor();
 		SwitchYardComponent component = editor.addComponent();
@@ -317,6 +319,7 @@ public class SwitchYardEditorImplementationsTest {
 	}
 
 	@Test
+	@RunIf(conditionClass = SwitchYardRequirementSupportBPMN.class)
 	public void addExistingBPMNImplementationWithKnowledgeContainerTest() throws Exception {
 		SwitchYardEditor editor = new SwitchYardEditor();
 		SwitchYardComponent component = editor.addComponent();
@@ -354,6 +357,7 @@ public class SwitchYardEditorImplementationsTest {
 	}
 
 	@Test
+	@RunIf(conditionClass = SwitchYardRequirementSupportBPMN.class)
 	public void addExistingBPMNImplementationWithRemoteJMSTest() throws Exception {
 		SwitchYardEditor editor = new SwitchYardEditor();
 		SwitchYardComponent component = editor.addComponent();
@@ -409,6 +413,7 @@ public class SwitchYardEditorImplementationsTest {
 	}
 
 	@Test
+	@RunIf(conditionClass = SwitchYardRequirementSupportBPMN.class)
 	public void addExistingBPMNImplementationWithRemoteRESTTest() throws Exception {
 		SwitchYardEditor editor = new SwitchYardEditor();
 		SwitchYardComponent component = editor.addComponent();
@@ -439,8 +444,7 @@ public class SwitchYardEditorImplementationsTest {
 	}
 
 	@Test
-	@Jira("SWITCHYARD-2782")
-	@RunIf(conditionClass = IssueIsClosed.class)
+	@RunIf(conditionClass = SwitchYardRequirementSupportDrools.class)
 	public void addDroolsImplementationWithNewJavaInterfaceTest() throws Exception {
 		SwitchYardEditor editor = new SwitchYardEditor();
 		DroolsServiceWizard droolsWizard = editor.addDroolsImplementation();
@@ -467,6 +471,7 @@ public class SwitchYardEditorImplementationsTest {
 	}
 
 	@Test
+	@RunIf(conditionClass = SwitchYardRequirementSupportDrools.class)
 	public void addExistingDroolsImplementationTest() throws Exception {
 		SwitchYardEditor editor = new SwitchYardEditor();
 		SwitchYardComponent component = editor.addComponent();
@@ -492,6 +497,7 @@ public class SwitchYardEditorImplementationsTest {
 	}
 
 	@Test
+	@RunIf(conditionClass = SwitchYardRequirementSupportDrools.class)
 	public void addExistingDroolsImplementationWithKnowledgeContainerTest() throws Exception {
 		SwitchYardEditor editor = new SwitchYardEditor();
 		SwitchYardComponent component = editor.addComponent();
@@ -529,6 +535,8 @@ public class SwitchYardEditorImplementationsTest {
 	}
 
 	@Test
+	@Ignore("Removed as a part of SWITCHYARD-2817")
+	@RunIf(conditionClass = SwitchYardRequirementSupportDrools.class)
 	public void addExistingDroolsImplementationWithRemoteJMSTest() throws Exception {
 		SwitchYardEditor editor = new SwitchYardEditor();
 		SwitchYardComponent component = editor.addComponent();
@@ -584,6 +592,8 @@ public class SwitchYardEditorImplementationsTest {
 	}
 
 	@Test
+	@Ignore("Removed as a part of SWITCHYARD-2817")
+	@RunIf(conditionClass = SwitchYardRequirementSupportDrools.class)
 	public void addExistingDroolsImplementationWithRemoteRESTTest() throws Exception {
 		SwitchYardEditor editor = new SwitchYardEditor();
 		SwitchYardComponent component = editor.addComponent();

--- a/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/condition/SwitchYardConditionException.java
+++ b/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/condition/SwitchYardConditionException.java
@@ -1,0 +1,20 @@
+package org.jboss.tools.switchyard.ui.bot.test.condition;
+
+/**
+ * 
+ * @author apodhrad
+ *
+ */
+public class SwitchYardConditionException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public SwitchYardConditionException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public SwitchYardConditionException(String message) {
+		super(message);
+	}
+
+}

--- a/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/condition/SwitchYardRequirementSupportBPMN.java
+++ b/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/condition/SwitchYardRequirementSupportBPMN.java
@@ -12,7 +12,7 @@ import org.junit.runners.model.FrameworkMethod;
  * @author apodhrad
  *
  */
-public class SwitchYardRequirementHasServer implements TestMethodShouldRun {
+public class SwitchYardRequirementSupportBPMN implements TestMethodShouldRun {
 
 	@Override
 	public boolean shouldRun(FrameworkMethod method) {
@@ -24,7 +24,14 @@ public class SwitchYardRequirementHasServer implements TestMethodShouldRun {
 			if (obj instanceof SwitchYardRequirement) {
 				SwitchYardRequirement switchYardRequirement = (SwitchYardRequirement) obj;
 				SwitchYardConfig config = switchYardRequirement.getConfig();
-				return config.getServerBase() != null;
+				String componentRestriction = config.getComponentRestriction();
+				if (componentRestriction == null) {
+					return true;
+				}
+				if (componentRestriction.contains("bpm")) {
+					return true;
+				}
+				return false;
 			}
 		} catch (Exception e) {
 			throw new SwitchYardConditionException("Cannot parse switchyardRequirement.", e);

--- a/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/condition/SwitchYardRequirementSupportDrools.java
+++ b/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/condition/SwitchYardRequirementSupportDrools.java
@@ -12,7 +12,7 @@ import org.junit.runners.model.FrameworkMethod;
  * @author apodhrad
  *
  */
-public class SwitchYardRequirementHasServer implements TestMethodShouldRun {
+public class SwitchYardRequirementSupportDrools implements TestMethodShouldRun {
 
 	@Override
 	public boolean shouldRun(FrameworkMethod method) {
@@ -24,7 +24,14 @@ public class SwitchYardRequirementHasServer implements TestMethodShouldRun {
 			if (obj instanceof SwitchYardRequirement) {
 				SwitchYardRequirement switchYardRequirement = (SwitchYardRequirement) obj;
 				SwitchYardConfig config = switchYardRequirement.getConfig();
-				return config.getServerBase() != null;
+				String componentRestriction = config.getComponentRestriction();
+				if (componentRestriction == null) {
+					return true;
+				}
+				if (componentRestriction.contains("drools") || componentRestriction.contains("rules")) {
+					return true;
+				}
+				return false;
 			}
 		} catch (Exception e) {
 			throw new SwitchYardConditionException("Cannot parse switchyardRequirement.", e);

--- a/tests/org.jboss.tools.teiid.ui.bot.test/src/org/jboss/tools/teiid/ui/bot/test/ModelWizardTest.java
+++ b/tests/org.jboss.tools.teiid.ui.bot.test/src/org/jboss/tools/teiid/ui/bot/test/ModelWizardTest.java
@@ -2,14 +2,11 @@ package org.jboss.tools.teiid.ui.bot.test;
 
 import static org.junit.Assert.assertTrue;
 
-import org.jboss.reddeer.common.wait.AbstractWait;
-import org.jboss.reddeer.common.wait.TimePeriod;
 import org.jboss.reddeer.eclipse.core.resources.Project;
 import org.jboss.reddeer.eclipse.jdt.ui.ProjectExplorer;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.jboss.reddeer.swt.impl.button.PushButton;
-import org.jboss.reddeer.swt.impl.menu.ShellMenu;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.tools.teiid.reddeer.ModelClass;
 import org.jboss.tools.teiid.reddeer.ModelType;
@@ -18,7 +15,6 @@ import org.jboss.tools.teiid.reddeer.manager.ModelExplorerManager;
 import org.jboss.tools.teiid.reddeer.perspective.TeiidPerspective;
 import org.jboss.tools.teiid.reddeer.wizard.MetadataModelWizard;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,13 +42,6 @@ public class ModelWizardTest {
 	public static void beforeClass() {
 		teiidBot.uncheckBuildAutomatically();
 		new ModelExplorerManager().createProject(PROJECT_NAME);
-	}
-
-	@AfterClass
-	public static void saveAllFiles() {
-		AbstractWait.sleep(TimePeriod.NORMAL);
-		new ShellMenu("File", "Save All").select();
-		AbstractWait.sleep(TimePeriod.SHORT);
 	}
 
 	@After


### PR DESCRIPTION
The following error affects our verification job.

**Error Message**

Menu item is not enabled

**Stacktrace**
```
org.jboss.reddeer.core.exception.CoreLayerException: Menu item is not enabled
	at org.jboss.reddeer.core.handler.MenuHandler.select(MenuHandler.java:92)
	at org.jboss.reddeer.swt.impl.menu.ShellMenu.select(ShellMenu.java:72)
	at org.jboss.tools.teiid.ui.bot.test.ModelWizardTest.saveAllFiles(ModelWizardTest.java:54)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.jboss.reddeer.junit.internal.runner.statement.RunAfters.evaluate(RunAfters.java:66)
	at org.jboss.reddeer.junit.internal.runner.statement.CleanUpRequirementStatement.evaluate(CleanUpRequirementStatement.java:34)
	at org.jboss.reddeer.junit.internal.runner.statement.RunIAfterClassExtensions.evaluate(RunIAfterClassExtensions.java:48)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:146)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:208)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:156)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:82)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:91)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:73)
	at java.lang.Thread.run(Thread.java:745)
```

**Standard Output**
```
14:05:12.284 INFO [WorkbenchTestable][RequirementsRunner] Finished test: relationalSourceModel as-711_teiid-830.xml(org.jboss.tools.teiid.ui.bot.test.ModelWizardTest)
14:05:22.284 DEBUG [WorkbenchTestable][AbstractWait] Waiting until active shell exists...
14:05:22.284 DEBUG [WorkbenchTestable][AbstractWait] Waiting until active shell exists finished successfully
14:05:22.285 INFO [main][MenuLookup] Getting Menu Bar of shell 'Teiid Designer - ModelWizardTestProject/relational_source.xmi - '
14:05:22.289 DEBUG [main][MenuLookup] Found menu:'File'
14:05:22.289 DEBUG [main][MenuLookup] Item match:File
14:05:22.293 DEBUG [main][MenuLookup] Found menu:'New	Shift+Alt+N'
14:05:22.293 DEBUG [main][MenuLookup] Found menu:'Open File...'
14:05:22.293 DEBUG [main][MenuLookup] Found menu:''
14:05:22.293 DEBUG [main][MenuLookup] Found menu:'Close	Ctrl+W'
14:05:22.293 DEBUG [main][MenuLookup] Found menu:'Close All	Shift+Ctrl+W'
14:05:22.293 DEBUG [main][MenuLookup] Found menu:''
14:05:22.293 DEBUG [main][MenuLookup] Found menu:'Save	Ctrl+S'
14:05:22.293 DEBUG [main][MenuLookup] Found menu:'Save As...'
14:05:22.293 DEBUG [main][MenuLookup] Found menu:'Save All	Shift+Ctrl+S'
14:05:22.293 DEBUG [main][MenuLookup] Item match:Save All	Shift+Ctrl+S
14:05:22.294 DEBUG [WorkbenchTestable][MenuHandler] Queried MenuItem text:"Sav&e All	Shift+Ctrl+S"
14:05:22.294 INFO [WorkbenchTestable][ShellMenu] Select shell menu with text Sav&e All	Shift+Ctrl+S
14:05:22.294 DEBUG [main][Display] UI Call chaining attempt
14:05:22.299 DEBUG [main][ScreenshotCapturer] Capturing Screenshot: ./target/screenshots/as-711_teiid-830.xml/org.jboss.tools.teiid.ui.bot.test.ModelWizardTest.saveAllFiles@AfterClass.png
14:05:22.461 DEBUG [main][ScreenshotCapturer] Screenshot successfully captured. Saved in /home/jbossqa/workspace/jbtis43x.verification.job/tests/org.jboss.tools.teiid.ui.bot.test/./target/screenshots/as-711_teiid-830.xml/org.jboss.tools.teiid.ui.bot.test.ModelWizardTest.saveAllFiles@AfterClass.png
14:05:22.461 DEBUG [WorkbenchTestable][RunIAfterClassExtensions] Run after class extensions for test class org.jboss.tools.teiid.ui.bot.test.ModelWizardTest
14:05:22.461 DEBUG [WorkbenchTestable][RunIAfterClassExtensions] Run method runAfterTestClass() of class org.jboss.reddeer.junit.extension.after.test.impl.CloseAllShellsExt
14:05:22.461 INFO [WorkbenchTestable][ShellHandler] Closing all shells...
14:05:22.463 DEBUG [WorkbenchTestable][AbstractWait] Waiting until active shell exists...
14:05:22.463 DEBUG [WorkbenchTestable][AbstractWait] Waiting until active shell exists finished successfully
```