### PR TITLE
JBTIS-843: SwitchYard Tests sometimes fail due to unability to find CTab

### DIFF
--- a/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/ProjectExplorerProjectCapabilitiesTest.java
+++ b/tests/org.jboss.tools.switchyard.ui.bot.test/src/org/jboss/tools/switchyard/ui/bot/test/ProjectExplorerProjectCapabilitiesTest.java
@@ -158,9 +158,13 @@ public class ProjectExplorerProjectCapabilitiesTest {
 	@Test
 	public void projectCapabilitiesVersionTest() {
 		new SwitchYardProject(SY_PROJECT).openSwitchYardFile();
+		// a workaround for SWITCHYARD-2907
+		new SwitchYardEditor().saveAndClose();
 		/* Set configuration version to 1.0 */
 		ProjectCapabilitiesShell capabilities = new SwitchYardProject(SY_PROJECT).configureCapabilities();
 		capabilities.setConfigurationVersion("1.0").ok();
+		// a workaround for SWITCHYARD-2907
+		new SwitchYardProject(SY_PROJECT).openSwitchYardFile();
 		assertSwitchYardNamespace("1.0");
 		/* Set configuration version to 1.1 */
 		capabilities = new SwitchYardProject(SY_PROJECT).configureCapabilities();


### PR DESCRIPTION
org.jboss.reddeer.swt.exception.SWTLayerException: No matching widget found
	at org.jboss.reddeer.swt.wait.AbstractWait.timeoutExceeded(AbstractWait.java:157)
	at org.jboss.reddeer.swt.wait.AbstractWait.wait(AbstractWait.java:110)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:75)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:51)
	at org.jboss.reddeer.swt.wait.AbstractWait.<init>(AbstractWait.java:39)
	at org.jboss.reddeer.swt.wait.WaitUntil.<init>(WaitUntil.java:23)
	at org.jboss.reddeer.swt.lookup.WidgetLookup.activeWidget(WidgetLookup.java:71)
	at org.jboss.reddeer.swt.widgets.AbstractWidget.<init>(AbstractWidget.java:30)
	at org.jboss.reddeer.swt.impl.ctab.AbstractCTabItem.<init>(AbstractCTabItem.java:28)
	at org.jboss.reddeer.swt.impl.ctab.DefaultCTabItem.<init>(DefaultCTabItem.java:79)
	at org.jboss.reddeer.swt.impl.ctab.DefaultCTabItem.<init>(DefaultCTabItem.java:44)
	at org.jboss.reddeer.swt.impl.ctab.DefaultCTabItem.<init>(DefaultCTabItem.java:35)
	at org.jboss.tools.switchyard.reddeer.editor.SwitchYardEditor.activateDesignTab(SwitchYardEditor.java:79)
	at org.jboss.tools.switchyard.reddeer.editor.SwitchYardEditor.<init>(SwitchYardEditor.java:73)
	at org.jboss.tools.switchyard.reddeer.project.SwitchYardProject.openSwitchYardFile(SwitchYardProject.java:46)
	at org.jboss.tools.switchyard.ui.bot.test.ValidatorsTest.openSwitchYardFile(ValidatorsTest.java:63)