### PR TITLE
JBTIS-862: Fuse: Fix errors in Regression tests

### DIFF
--- a/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/RegressionTest.java
+++ b/tests/org.jboss.tools.fuse.ui.bot.test/src/org/jboss/tools/fuse/ui/bot/test/RegressionTest.java
@@ -323,7 +323,7 @@ public class RegressionTest extends DefaultTest {
 		new ContextMenu("Run As", "Run Configurations...").select();
 		new WaitUntil(new ShellWithTextIsAvailable("Run Configurations"));
 		new DefaultShell("Run Configurations");
-		new DefaultTreeItem("Apache Tomcat").select();
+		new DefaultTreeItem("Java Application").select();
 		try {
 			new DefaultTreeItem("Apache Karaf Launcher").select();
 			fail("Run Configurations contains forbidden item");


### PR DESCRIPTION
- fix problem with non existing run configuration type 'Apache Tomcat'