### PR TITLE
JBTIS-1057 - Fuse: Fix Project creation test

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -11,7 +11,7 @@
 	<name>integration-stack-tests.tests</name>
 	<packaging>pom</packaging>
 	<properties>
-		<surefire.timeout>10800</surefire.timeout>
+		<surefire.timeout>21600</surefire.timeout>
 		<memoryOptions2>-XX:MaxPermSize=384m</memoryOptions2>
 		<swt.bot.test.record.screencast>false</swt.bot.test.record.screencast>
 		<pauseFailedTest>false</pauseFailedTest>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTIS-1057

Prolong surefire.timeout from 3 hours to 6 hours